### PR TITLE
Add inline comments support in lammps atoms positions file

### DIFF
--- a/atomman/defect/differential_displacement.py
+++ b/atomman/defect/differential_displacement.py
@@ -172,7 +172,7 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
             ax1.add_patch(mpatches.Circle(pos_1[i, :2], atom_circle_radius, fc=color, ec='k'))
         else : 
             # Plot a circle for atom i in system 0
-            color = cm.hsv((pos_0[i, 2] - zlim[0]) / (zlim[1] - zlim[0]))
+            color = cm.binary((pos_0[i, 2] - zlim[0]) / (zlim[1] - zlim[0]))
             ax1.add_patch(mpatches.Circle(pos_0[i, :2], atom_circle_radius, fc=color, ec='k'))
 
         # Compute distance vectors between atom i and its neighbors for both systems

--- a/atomman/defect/differential_displacement.py
+++ b/atomman/defect/differential_displacement.py
@@ -10,7 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib import cm
-
+from ipdb import set_trace as st
 # atomman imports
 from ..tools import axes_check
 from .. import NeighborList
@@ -20,10 +20,10 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
                               neighbors=None, cutoff=None,
                               component='standard', axes=None,
                               plot_scale=1, save_file=None, show=True,
-                              plot_axes=None):
+                              display_atype2=False, display_system1_atoms=False):
     """
     Generates a differential displacement plot for characterizing dislocations.
-
+    
     Parameters
     ----------
     system_0 : atomman.system
@@ -83,20 +83,18 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
         If given then the plot will be saved to a file with this name.
     show : bool, optional
         Flag for showing the figure. Default is True.
-    plot_axes : matplotlib.Axes.axes object
-        Existing axes to plot on, allows to pass existing matplotlib axes
-        have full control of the graph outside the function.
-        Makes possible to plot multiple differential displacement
-        maps using subplots.
-        Default is None, then new graph is created by plt.subplots()
-
+    display_atype2 : bool, optional
+        Flag for showing solute elements, eg C in a Fe dislocation core. Default is False.
+    display_system1_atoms : bool, optional
+        Flag for draw the circles at the final position of the atoms, instead of the perfect
+        crystal atoms positions. Default is False.
+    
     """
     # Transform burgers using axes
     if axes is not None:
         T = axes_check(axes)
         burgers = T.dot(burgers)
-
-
+    
     # Neighbor list setup
     if neighbors is not None:
         assert cutoff is None, 'neighbors and cutoff cannot both be given'
@@ -106,7 +104,7 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
         neighbors = system_0.neighbors
     else:
         raise ValueError('neighbors or cutoff is required')
-
+    
     # Give numeric values for str plot axis terms
     if plotxaxis == 'x':
         plotxaxis = [1.0,0.0,0.0]
@@ -114,27 +112,28 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
         plotxaxis = [0.0,1.0,0.0]
     elif plotxaxis == 'z':
         plotxaxis = [0.0,0.0,1.0]
-
+    
     if plotyaxis == 'x':
         plotyaxis = [1.0,0.0,0.0]
     elif plotyaxis == 'y':
         plotyaxis = [0.0,1.0,0.0]
     elif plotyaxis == 'z':
         plotyaxis = [0.0,0.0,1.0]
-
+    
     # Build transformation matrix, T, from plot axes.
     plotxaxis = np.asarray(plotxaxis, dtype='float64')
     plotyaxis = np.asarray(plotyaxis, dtype='float64')
     T = axes_check([plotxaxis, plotyaxis, np.cross(plotxaxis, plotyaxis)])
-
+    
     # Extract positions and transform using T
     pos_0 = np.inner(system_0.atoms.pos, T)
-
+    pos_1 = np.inner(system_1.atoms.pos, T)
+    
     # Transform burgers using plot axes and separate magnitude and direction
     burgers = T.dot(burgers)
     burgers_mag = np.linalg.norm(burgers)
     burgers_uvect = burgers / burgers_mag
-
+    
     # Set plot limits
     if xlim is None:
         xlim = (pos_0[:, 0].min(), pos_0[:, 0].max())
@@ -142,7 +141,7 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
         ylim = (pos_0[:, 1].min(), pos_0[:, 1].max())
     if zlim is None:
         zlim = (pos_0[:, 2].min(), pos_0[:, 2].max())
-
+    
     # Identify only atoms in xlim, ylim, zlim
     in_bounds = ((pos_0[:,0] > xlim[0] - 5.) &
                  (pos_0[:,0] < xlim[1] + 5.) &
@@ -151,49 +150,57 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
                  (pos_0[:,2] > zlim[0]) &
                  (pos_0[:,2] < zlim[1]))
 
-    # if plot_axes are passsed do not create new
-    if plot_axes is not None:
-        ax1 = plot_axes
-    else:
-        # Initial plot setup and parameters
-        fig, ax1, = plt.subplots(1, 1, squeeze=True, figsize=(7,7), dpi=72)
-
-
+    # Initial plot setup and parameters
+    fig, ax1, = plt.subplots(1, 1, squeeze=True, figsize=(7,7), dpi=72)
     ax1.axis([xlim[0], xlim[1], ylim[0], ylim[1]])
     atom_circle_radius = burgers_mag / 10
     arrow_width_scale = 1. / 200.
+    
+    if display_atype2 :
+        # Display atoms of atype2 (e.g. solutes), in final position
+        df = system_1.atoms.df()[system_1.atoms.df()["atype"]==2]
+        pos_C = np.array([df["pos[0]"].values, df["pos[1]"].values, df["pos[2]"].values ])
+        for atom_x, atom_y, atom_z in pos_C.T:
+            ax1.add_patch(mpatches.Circle((atom_x, atom_y, atom_z), atom_circle_radius, fc="red", ec='k'))
 
     # Loop over all atoms i in plot range
     for i in np.arange(system_0.natoms)[in_bounds]:
-
-        # Plot a circle for atom i
-        color = cm.hsv((pos_0[i, 2] - zlim[0]) / (zlim[1] - zlim[0]))
-        ax1.add_patch(mpatches.Circle(pos_0[i, :2], atom_circle_radius, fc=color, ec='k'))
+        
+        if display_system1_atoms:
+            # Plot a circle for atom i in system 1
+            color = cm.hsv((pos_1[i, 2] - zlim[0]) / (zlim[1] - zlim[0]))
+            ax1.add_patch(mpatches.Circle(pos_1[i, :2], atom_circle_radius, fc=color, ec='k'))
+        else : 
+            # Plot a circle for atom i in system 0
+            color = cm.hsv((pos_0[i, 2] - zlim[0]) / (zlim[1] - zlim[0]))
+            ax1.add_patch(mpatches.Circle(pos_0[i, :2], atom_circle_radius, fc=color, ec='k'))
 
         # Compute distance vectors between atom i and its neighbors for both systems
         dvectors_0 = np.inner(system_0.dvect(int(i), neighbors[i]), T)
         dvectors_1 = np.inner(system_1.dvect(int(i), neighbors[i]), T)
-
+    
         # Compute differential displacement vectors
         dd_vectors = dvectors_1 - dvectors_0
-
-        # Compute center point positions for the vectors
-        arrow_centers = pos_0[i] + dvectors_0 / 2
-
+        
+        if display_system1_atoms:
+            # Compute center point positions for the vectors
+            arrow_centers = pos_1[i] + dvectors_1 / 2
+        else :
+            arrow_centers = pos_0[i] + dvectors_0 / 2
         # Plot standard differential displacement component
         if component == 'standard':
             # Compute unit distance vectors
             uvectors_0 = dvectors_0 / np.linalg.norm(dvectors_0, axis=1)[:,np.newaxis]
-
+            
             # Compute component of the dd_vector parallel to the burgers vector
             dd_components = dd_vectors.dot(burgers_uvect)
             dd_components[dd_components > burgers_mag / 2] -= burgers_mag
             dd_components[dd_components < -burgers_mag / 2] += burgers_mag
-
+            
             # Scale arrow lengths and vectors
             arrow_lengths = uvectors_0 * dd_components[:,np.newaxis] * plot_scale
             arrow_widths = arrow_width_scale * dd_components * plot_scale
-
+        
             # Plot the arrows
             for center, length, width in zip(arrow_centers, arrow_lengths,
                                              arrow_widths):
@@ -202,6 +209,7 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
                                pivot='middle', angles='xy', scale_units='xy',
                                scale=1, width=width)
 
+        
         # Plot xy differential displacement component
         elif component == 'xy':
             # Scale arrow lengths and vectors
@@ -209,17 +217,15 @@ def differential_displacement(system_0, system_1, burgers, plotxaxis='x',
             arrow_lengths[dd_vectors[:, 2] > 0] *= -1
             arrow_widths = arrow_width_scale * (arrow_lengths[:,0]**2
                                               + arrow_lengths[:,1]**2)**0.5
-
+            
             # Plot the arrows
             for center, length, width in zip(arrow_centers, arrow_lengths, arrow_widths):
                 if width > 1e-7:
                     ax1.quiver(center[0], center[1], length[0], length[1], width=width,
                                pivot='middle', angles='xy', scale_units='xy', scale=1)
-
-    if plot_axes is None:
-        if save_file is not None:
-            plt.savefig(save_file, dpi=800)
-        if show == False:
-            plt.close(fig)
-        else:
-            plt.show()
+    
+    if save_file is not None:
+        plt.savefig(save_file, dpi=800)
+    if show == False:
+        plt.close(fig)
+    plt.show()

--- a/atomman/load/atom_data/load.py
+++ b/atomman/load/atom_data/load.py
@@ -61,42 +61,42 @@ def load(data, pbc=(True, True, True), symbols=None, atom_style='atomic', units=
                 
                 # Read number of atoms 
                 if len(terms) == 2 and terms[1] == 'atoms' \
-                    or len(terms) >= 2 and terms[1] == 'atoms' and terms[2][0] == '#':
+                    or len(terms) > 2 and terms[1] == 'atoms' and terms[2][0] == '#':
                     natoms = int(terms[0])
                 
                 # Read number of atom types
                 elif len(terms) == 3 and terms[1] == 'atom' and terms[2] == 'types' \
-                    or len(terms) >= 3 and terms[1] == 'atom' and terms[2] == 'types' and terms[3][0] == '#': 
+                    or len(terms) > 3 and terms[1] == 'atom' and terms[2] == 'types' and terms[3][0] == '#': 
                     #natypes = int(terms[0])
                     pass
                 
                 # Read boundary info
                 elif len(terms) == 4 and terms[2] == 'xlo' and terms[3] == 'xhi' \
-                    or len(terms) >= 4 and terms[2] == 'xlo' and terms[3] == 'xhi' and terms[4][0] == '#':
+                    or len(terms) > 4 and terms[2] == 'xlo' and terms[3] == 'xhi' and terms[4][0] == '#':
                     xlo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     xhi = uc.set_in_units(float(terms[1]), units_dict['length'])
                 elif len(terms) == 4 and terms[2] == 'ylo' and terms[3] == 'yhi' \
-                    or len(terms) >= 4 and terms[2] == 'ylo' and terms[3] == 'yhi' and terms[4][0] == '#':
+                    or len(terms) > 4 and terms[2] == 'ylo' and terms[3] == 'yhi' and terms[4][0] == '#':
                     ylo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     yhi = uc.set_in_units(float(terms[1]), units_dict['length'])
                 elif len(terms) == 4 and terms[2] == 'zlo' and terms[3] == 'zhi' \
-                    or len(terms) >= 4 and terms[2] == 'zlo' and terms[3] == 'zhi' and terms[4][0] == '#':
+                    or len(terms) > 4 and terms[2] == 'zlo' and terms[3] == 'zhi' and terms[4][0] == '#':
                     zlo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     zhi = uc.set_in_units(float(terms[1]), units_dict['length'])
                 elif len(terms) == 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz' \
-                    or len(terms)>= 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz' and terms[6][0] == '#':
+                    or len(terms) > 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz' and terms[6][0] == '#':
                     xy = uc.set_in_units(float(terms[0]), units_dict['length'])
                     xz = uc.set_in_units(float(terms[1]), units_dict['length'])
                     yz = uc.set_in_units(float(terms[2]), units_dict['length'])
                 
                 # Identify starting line number for Atoms data
                 elif len(terms) == 1 and terms[0] == 'Atoms' \
-                    or len(terms) >= 1 and terms[0] == 'Atoms' and terms[1][0] == '#':
+                    or len(terms) > 1 and terms[0] == 'Atoms' and terms[1][0] == '#':
                     atomsstart = i + 1
                 
                 # Identify starting line number for Velocity data
                 elif len(terms) == 1 and terms[0] == 'Velocities' \
-                    or len(terms) >= 1 and terms[0] == 'Velocities' and terms[1][0] == '#':
+                    or len(terms) > 1 and terms[0] == 'Velocities' and terms[1][0] == '#':
                     velocitiesstart = i + 1
     
     # Create system

--- a/atomman/load/atom_data/load.py
+++ b/atomman/load/atom_data/load.py
@@ -60,35 +60,43 @@ def load(data, pbc=(True, True, True), symbols=None, atom_style='atomic', units=
             if len(terms)>0:
                 
                 # Read number of atoms 
-                if len(terms) == 2 and terms[1] == 'atoms':
+                if len(terms) == 2 and terms[1] == 'atoms' \
+                    or len(terms) >= 2 and terms[1] == 'atoms' and terms[2][0] == '#':
                     natoms = int(terms[0])
                 
                 # Read number of atom types
-                elif len(terms) == 3 and terms[1] == 'atom' and terms[2] == 'types': 
+                elif len(terms) == 3 and terms[1] == 'atom' and terms[2] == 'types' \
+                    or len(terms) >= 3 and terms[1] == 'atom' and terms[2] == 'types' and terms[3][0] == '#': 
                     #natypes = int(terms[0])
                     pass
                 
                 # Read boundary info
-                elif len(terms) == 4 and terms[2] == 'xlo' and terms[3] == 'xhi':
+                elif len(terms) == 4 and terms[2] == 'xlo' and terms[3] == 'xhi' \
+                    or len(terms) >= 4 and terms[2] == 'xlo' and terms[3] == 'xhi' and terms[4][0] == '#':
                     xlo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     xhi = uc.set_in_units(float(terms[1]), units_dict['length'])
-                elif len(terms) == 4 and terms[2] == 'ylo' and terms[3] == 'yhi':
+                elif len(terms) == 4 and terms[2] == 'ylo' and terms[3] == 'yhi' \
+                    or len(terms) >= 4 and terms[2] == 'ylo' and terms[3] == 'yhi' and terms[4][0] == '#':
                     ylo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     yhi = uc.set_in_units(float(terms[1]), units_dict['length'])
-                elif len(terms) == 4 and terms[2] == 'zlo' and terms[3] == 'zhi':
+                elif len(terms) == 4 and terms[2] == 'zlo' and terms[3] == 'zhi' \
+                    or len(terms) >= 4 and terms[2] == 'zlo' and terms[3] == 'zhi' and terms[4][0] == '#':
                     zlo = uc.set_in_units(float(terms[0]), units_dict['length'])
                     zhi = uc.set_in_units(float(terms[1]), units_dict['length'])
-                elif len(terms) == 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz':
+                elif len(terms) == 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz' \
+                    or len(terms)>= 6 and terms[3] == 'xy' and terms[4] == 'xz' and terms[5] == 'yz' and terms[6][0] == '#':
                     xy = uc.set_in_units(float(terms[0]), units_dict['length'])
                     xz = uc.set_in_units(float(terms[1]), units_dict['length'])
                     yz = uc.set_in_units(float(terms[2]), units_dict['length'])
                 
                 # Identify starting line number for Atoms data
-                elif len(terms) == 1 and terms[0] == 'Atoms':
+                elif len(terms) == 1 and terms[0] == 'Atoms' \
+                    or len(terms) >= 1 and terms[0] == 'Atoms' and terms[1][0] == '#':
                     atomsstart = i + 1
                 
                 # Identify starting line number for Velocity data
-                elif len(terms) == 1 and terms[0] == 'Velocities':
+                elif len(terms) == 1 and terms[0] == 'Velocities' \
+                    or len(terms) == 1 and terms[0] == 'Velocities' and terms[1][0] == '#':
                     velocitiesstart = i + 1
     
     # Create system

--- a/atomman/load/atom_data/load.py
+++ b/atomman/load/atom_data/load.py
@@ -96,7 +96,7 @@ def load(data, pbc=(True, True, True), symbols=None, atom_style='atomic', units=
                 
                 # Identify starting line number for Velocity data
                 elif len(terms) == 1 and terms[0] == 'Velocities' \
-                    or len(terms) == 1 and terms[0] == 'Velocities' and terms[1][0] == '#':
+                    or len(terms) >= 1 and terms[0] == 'Velocities' and terms[1][0] == '#':
                     velocitiesstart = i + 1
     
     # Create system


### PR DESCRIPTION
Hi,

I encountered a little incompatibility reading a file saved by Ovito, and propose a workaround. 

Motivations :

* Some external programs or tools tend to add inline comments in lammps atom_data files.
For example in ovito, "Atoms" is followed by "# atomic", specifying the atom_style.
Atomman raises a ValueError when reading the following file :
```
# LAMMPS data file written by OVITO
135 atoms
1 atom types
0.0 34.61129 xlo xhi
0.0 17.9845544 ylo yhi
0.0 2.4473877 zlo zhi
17.305645 0.0 0.0 xy xz yz

Atoms # atomic

1 1 0.0 0.0 2.826e-04
2 1 2.3074207 0.0 1.6315913
3 1 4.6148386 0.0 0.8157957
4 1 6.922259 0.0 0.0
5 1 9.2296772 0.0 1.6315913
...
...
```


* User may want to write inline comments !