### PR TITLE
BUG: support for Lammps unwrapped positions flags

### DIFF
--- a/atomman/load/atom_data/load.py
+++ b/atomman/load/atom_data/load.py
@@ -116,7 +116,8 @@ def load(data, pbc=(True, True, True), symbols=None, atom_style='atomic', units=
     if atomsstart is not None:
         prop_info = atoms_prop_info(atom_style, units)
         system = load_table(data, box=system.box, system=system, symbols=symbols,
-                            prop_info=prop_info, skiprows=atomsstart, nrows=natoms,
+                            prop_info=prop_info, skiprows=atomsstart, usecols=[0,1,2,3,4],
+                            nrows=natoms,
                             comment='#')
     else:
         raise ValueError('No Atoms section found!')
@@ -126,6 +127,7 @@ def load(data, pbc=(True, True, True), symbols=None, atom_style='atomic', units=
         prop_info = velocities_prop_info(atom_style, units)
         system = load_table(data, box=system.box, system=system,
                             prop_info=prop_info,
-                            skiprows=velocitiesstart, nrows=natoms)
+                            skiprows=velocitiesstart, usecols=[0,1,2,3],
+                            nrows=natoms)
     
     return system

--- a/atomman/load/table/load.py
+++ b/atomman/load/table/load.py
@@ -16,7 +16,7 @@ from ...tools import uber_open_rmode
 
 def load(table, box, symbols=None, system=None, prop_name=None, table_name=None,
          shape=None, unit=None, dtype=None, prop_info=None, skiprows=None,
-         nrows=None, comment=None):
+         usecols=None, nrows=None, comment=None):
     """
     Reads in tabular data into atomic properties.
     
@@ -57,6 +57,9 @@ def load(table, box, symbols=None, system=None, prop_name=None, table_name=None,
         'table_name', 'shape', 'unit', and 'dtype' fields.
     skiprows : int, optional
         Number of rows to skip before reading the data.
+    usecols : int, optional
+        Which columns are to be used. Will be passed to pandas.read_csv() usecols
+        option.
     nrows : int, optional
         Number of rows of data to read.
     comment : str, optional
@@ -80,7 +83,7 @@ def load(table, box, symbols=None, system=None, prop_name=None, table_name=None,
     
     # Read in table to dataframe
     with uber_open_rmode(table) as f:
-        df = pd.read_csv(f, delim_whitespace=True, names=table_name, skiprows=skiprows,
+        df = pd.read_csv(f, delim_whitespace=True, usecols=usecols, names=table_name, skiprows=skiprows,
                          nrows=nrows, comment=comment)
     if 'id' in df:
         df = df.sort_values('id')


### PR DESCRIPTION
## Problem
When using Lammps `write_data` command, positions are written to a file, but lammps also appends 3 flags to each line (0, 1 or -1). Those flags seemed not to be handled properly by `atomman.load()`. 

The format of the file is :

```
LAMMPS data file via write_data, version 12 Dec 2018, timestep = 890

2401 atoms
2 atom types

0.0000000000000000e+00 4.8753396899999997e+00 xlo xhi
0.0000000000000000e+00 1.3789543033000001e+02 ylo yhi
0.0000000000000000e+00 7.9613963819999995e+01 zlo zhi
1.2188349234708999e+00 0.0000000000000000e+00 0.0000000000000000e+00 xy xz yz

Masses
1 55.845
2 12.0107
Atoms # atomic

1 1 4.8765104789049962e+00 1.3789342338922083e+02 1.1450350660986815e-01 0 -1 0
2 1 3.6611610851732395e+00 3.4400882966388346e+00 2.0006436506550074e+00 0 0 0
3 1 4.0975803870990607e-01 2.2922423181836922e+00 1.1406317768252468e-01 0 0 0
4 1 4.1334129904729944e-01 5.7347193960639613e+00 1.9995265951218959e+00 0 0 0
5 1 4.4713841751949106e+00 1.1454753812346155e+00 2.0013169323956683e+00 0 0 0
...
```
For more details, see https://lammps.sandia.gov/doc/read_data.html , paragraph starting with "LAMMPS always stores atom coordinates as values which are inside the simulation box."

## Steps to reproduce

The following Lammps script was used. It generated the file presented above.

```bash
units metal
atom_style atomic
boundary p p p
read_data box.lmp # this box was created and saved using atomman

mass 1 55.845000
mass 2 12.011

pair_style eam/alloy
pair_coeff * * my-pot.eam Fe C

minimize 0 1e-05 100000 100000
write_data minimized.lmp
```
When using atomman.load("atom_data", "minimized.lmp"), the returned System contained 29 atypes, instead of the 2 expected, meaning the file was not parsed properly.

## Proposed solution
The proposed fix consists in ignoring those flags when reading the table. It's easily done by using the `usecols` options of `pd.read_csv()`.
What I did for the moment is hardcode which columns are to be used for `load('atom_data')` with atom_style set to atomic (i.e [1, 2, 3, 4]). 
It is improvable to support other atom_styles. I think `usecols` should be set in `velocities_prop_info` depending on the `atom_style`, but I'm not sure it's the way you want to do it though.
Anyway, this is a very modest contribution to try to help, it's not claimed to be merge-ready or anything ;) 

### Discussion
Possible limitations : 
- Works for atom_style set to atomic, not tested for others.
- Maybe it would be better to return the unwrapped coordinates, instead of ignoring the flags ?

Thanks for your work on atomman,