### PR TITLE
Add `unique_shifts` method for `atomman.defects.FreeSurface`

### DIFF
--- a/atomman/core/Box.py
+++ b/atomman/core/Box.py
@@ -17,35 +17,35 @@ class Box(Shape, object):
     """
     A representation of a triclinic (parallelepiped) box.
     """
-    
+
     def __init__(self, **kwargs):
         """
         Initializes a Box.  If parameters besides origin are given they
         must completely define the box.  Allowed parameter sets are:
-        
+
         - no parameters -> box is set to square unit box with origin = [0,0,0].
-        
+
         - origin. -> Only origin is changed (same as setting origin directly).
-        
+
         - vects, (and origin).
-        
+
         - avect, bvect, cvect, (and origin).
-        
+
         - a, b, c, (alpha, beta, gamma, and origin).
-        
+
         - lx, ly, lz, (xy, xz, yz, and origin).
-        
+
         - xlo, xhi, ylo, yhi, zlo, zhi, (xy, xz, and yz).
 
         - model
-        
+
         See the description of class methods and attributes for more details
         on the allowed parameters.
-        
+
         """
         self.__vects = np.eye(3, dtype='float64')
         self.__origin = np.zeros(3, dtype='float64')
-        
+
         if len(kwargs) > 0:
             if 'model' in kwargs:
                 if len(kwargs) > 1:
@@ -53,12 +53,12 @@ class Box(Shape, object):
                 self.model(kwargs['model'])
             else:
                 self.set(**kwargs)
-    
+
     @classmethod
     def cubic(cls, a):
         """
         Initializes a Box in standard cubic setting using only cubic lattice
-        parameters.  
+        parameters.
 
         a = b = c, alpha = beta = gamma = 90
 
@@ -77,7 +77,7 @@ class Box(Shape, object):
     def hexagonal(cls, a, c):
         """
         Initializes a Box in standard hexagonal setting using only hexagonal lattice
-        parameters.  
+        parameters.
 
         a = b != c, alpha = beta = 90, gamma = 120
 
@@ -101,7 +101,7 @@ class Box(Shape, object):
     def tetragonal(cls, a, c):
         """
         Initializes a Box in standard tetragonal setting using only tetragonal lattice
-        parameters.  
+        parameters.
 
         a = b != c, alpha = beta = gamma = 90
 
@@ -125,7 +125,7 @@ class Box(Shape, object):
     def trigonal(cls, a, alpha):
         """
         Initializes a Box in standard trigonal setting using only trigonal lattice
-        parameters.  
+        parameters.
 
         a = b = c, alpha = beta = gamma < 120
 
@@ -141,7 +141,7 @@ class Box(Shape, object):
         atomman.Box
         """
         if alpha >= 120.0:
-            raise ValueError('trigonal alpha angle must be less than 120 degrees')        
+            raise ValueError('trigonal alpha angle must be less than 120 degrees')
 
         return cls(a=a, b=a, c=a, alpha=alpha, beta=alpha, gamma=alpha)
 
@@ -149,7 +149,7 @@ class Box(Shape, object):
     def orthorhombic(cls, a, b, c):
         """
         Initializes a Box in standard orthorhombic setting using only orthorhombic lattice
-        parameters.  
+        parameters.
 
         a != b != c, alpha = beta = gamma = 90
 
@@ -175,7 +175,7 @@ class Box(Shape, object):
     def monoclinic(cls, a, b, c, beta):
         """
         Initializes a Box in standard monoclinic setting using only monoclinic lattice
-        parameters.  
+        parameters.
 
         a != b != c, alpha = gamma = 90, beta > 90
 
@@ -205,9 +205,9 @@ class Box(Shape, object):
     def triclinic(cls, a, b, c, alpha, beta, gamma):
         """
         Initializes a Box in standard triclinic setting using only triclinic lattice
-        parameters.  
+        parameters.
 
-        a != b != c, alpha != beta != gamma 
+        a != b != c, alpha != beta != gamma
 
         Parameters
         ----------
@@ -239,140 +239,140 @@ class Box(Shape, object):
     def vects(self):
         """numpy.ndarray : Array containing all three box vectors.  Can be set directly."""
         return deepcopy(self.__vects)
-    
+
     @vects.setter
     def vects(self, value):
         self.__vects[:] = value
-        
+
         #Zero out near zero terms
         self.__vects[np.isclose(self.__vects/abs(self.__vects).max(), 0.0, atol=1e-9)] = 0.0
-    
+
     @property
     def origin(self):
         """numpy.ndarray : Box origin position where vects are added to define the box.  Can be set directly."""
         return deepcopy(self.__origin)
-    
+
     @origin.setter
     def origin(self, value):
         self.__origin[:] = value
-    
+
     @property
     def avect(self):
         """numpy.ndarray : Vector associated with the a box dimension."""
         return self.vects[0]
-    
+
     @property
     def bvect(self):
         """numpy.ndarray : Vector associated with the b box dimension."""
         return self.vects[1]
-    
+
     @property
     def cvect(self):
         """numpy.ndarray : Vector associated with the c box dimension."""
         return self.vects[2]
-    
+
     @property
     def a(self):
         """float : The a lattice parameter (magnitude of avect)."""
         return (self.__vects[0,0]**2 + self.__vects[0,1]**2 + self.__vects[0,2]**2)**0.5
-    
+
     @property
     def b(self):
         """float : The b lattice parameter (magnitude of avect)."""
         return (self.__vects[1,0]**2 + self.__vects[1,1]**2 + self.__vects[1,2]**2)**0.5
-    
+
     @property
     def c(self):
         """float : The c lattice parameter (magnitude of avect)."""
-        return (self.__vects[2,0]**2 + self.__vects[2,1]**2 + self.__vects[2,2]**2)**0.5 
-    
+        return (self.__vects[2,0]**2 + self.__vects[2,1]**2 + self.__vects[2,2]**2)**0.5
+
     @property
     def alpha(self):
         """float : The alpha lattice angle in degrees (angle between bvect and cvect)."""
         return vect_angle(self.__vects[1], self.__vects[2])
-    
+
     @property
     def beta(self):
         """float : The beta lattice angle in degrees (angle between avect and cvect)."""
         return vect_angle(self.__vects[0], self.__vects[2])
-    
+
     @property
     def gamma(self):
         """float : The gamma lattice angle in degrees (angle between avect and bvect)."""
         return vect_angle(self.__vects[0], self.__vects[1])
-    
+
     @property
     def lx(self):
         """float : LAMMPS lx box length (avect[0] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[0,0]
-    
+
     @property
     def ly(self):
         """float : LAMMPS ly box length (bvect[1] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[1,1]
-    
+
     @property
     def lz(self):
         """float : LAMMPS lz box length (cvect[2] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[2,2]
-    
+
     @property
     def xy(self):
         """float : LAMMPS xy box tilt factor (bvect[0] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[1,0]
-    
+
     @property
     def xz(self):
         """float : LAMMPS xz box tilt factor (cvect[0] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[2,0]
-    
+
     @property
     def yz(self):
         """float : LAMMPS yz box tilt factor (cvect[1] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__vects[2,1]
-    
+
     @property
     def xlo(self):
         """float : LAMMPS xlo box lo term (origin[0] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[0]
-    
+
     @property
     def ylo(self):
         """float : LAMMPS ylo box lo term (origin[1] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[1]
-    
+
     @property
     def zlo(self):
         """float : LAMMPS zlo box lo term (origin[2] for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[2]
-    
+
     @property
     def xhi(self):
         """float : LAMMPS xhi box hi term (origin[0] + lx for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[0] + self.__vects[0,0]
-    
+
     @property
     def yhi(self):
         """float : LAMMPS yhi box hi term (origin[1] + ly for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[1] + self.__vects[1,1]
-    
+
     @property
     def zhi(self):
         """float : LAMMPS zhi box hi term (origin[2] + lz for normalized boxes)."""
         assert self.is_lammps_norm(), 'Box is not normalized for LAMMPS style parameters'
         return self.__origin[2] + self.__vects[2,2]
-    
+
     @property
     def volume(self):
         """float : The volume of the box."""
@@ -396,7 +396,7 @@ class Box(Shape, object):
                           'bvect =  [%6.3f, %6.3f, %6.3f]' % (self.__vects[1,0], self.__vects[1,1], self.__vects[1,2]),
                           'cvect =  [%6.3f, %6.3f, %6.3f]' % (self.__vects[2,0], self.__vects[2,1], self.__vects[2,2]),
                           'origin = [%6.3f, %6.3f, %6.3f]' % (self.__origin[0],  self.__origin[1],  self.__origin[2])])
-    
+
     def model(self, model=None, length_unit='angstrom'):
         """
         Reads or generates a data model for the box.
@@ -418,7 +418,7 @@ class Box(Shape, object):
         """
         # Set values if model given
         if model is not None:
-            
+
             # Find box element
             model = DM(model).find('box')
             avect = uc.value_unit(model['avect'])
@@ -426,7 +426,7 @@ class Box(Shape, object):
             cvect = uc.value_unit(model['cvect'])
             origin = uc.value_unit(model['origin'])
             self.set(avect=avect, bvect=bvect, cvect=cvect, origin=origin)
-        
+
         # Return DataModelDict if model not given
         else:
             model = DM()
@@ -442,30 +442,30 @@ class Box(Shape, object):
         """
         Sets a Box's dimensions.  If parameters besides origin are given they
         must completely define the box.  Allowed parameter sets are:
-        
+
         - no parameters -> box is set to square unit box with origin = [0,0,0].
-        
+
         - origin. -> Only origin is changed (same as setting origin directly).
-        
+
         - vects, (and origin).
-        
+
         - avect, bvect, cvect, (and origin).
-        
+
         - a, b, c, (alpha, beta, gamma, and origin).
-        
+
         - lx, ly, lz, (xy, xz, yz, and origin).
-        
+
         - xlo, xhi, ylo, yhi, zlo, zhi, (xy, xz, and yz).
-        
+
         See the description of class methods and attributes for more details
         on the allowed parameters.
         """
-        
+
         # Set default values if no kwargs given
         if len(kwargs) == 0:
             self.vects = np.eye(3)
             self.origin = np.zeros(3)
-        
+
         # Set directly if vects given
         elif 'vects' in kwargs:
             vects = kwargs.pop('vects')
@@ -473,36 +473,36 @@ class Box(Shape, object):
             assert len(kwargs) == 0, 'Invalid arguments'
             self.vects = vects
             self.origin = origin
-        
+
         # Call set_vectors if vect inputs given
         elif 'avect' in kwargs:
             self.set_vectors(**kwargs)
-        
+
         # Call set_lengths if length inputs given
         elif 'lx' in kwargs:
             self.set_lengths(**kwargs)
-        
+
         # Call set_hi_los if hi/lo inputs given
         elif 'xlo' in kwargs:
             self.set_hi_los(**kwargs)
-        
+
         # Call set_abc if vector magnitudes are given
         elif 'a' in kwargs:
             self.set_abc(**kwargs)
-        
+
         # Set only origin if given alone
         elif 'origin' in kwargs:
             origin = kwargs.pop('origin')
             assert len(kwargs) == 0, 'Invalid arguments'
             self.origin = origin
-        
+
         else:
             raise TypeError('Invalid arguments')
-    
+
     def set_vectors(self, avect, bvect, cvect, origin=None):
         """
         Set the box using the three box vectors.
-        
+
         Parameters
         ----------
         avect : numpy.ndarray
@@ -518,15 +518,15 @@ class Box(Shape, object):
         # Set default origin
         if origin is None:
             origin = [0.0, 0.0, 0.0]
-        
+
         # Combine avect, bvect and cvect into vects and set directly
         self.vects = [avect, bvect, cvect]
         self.origin = origin
-        
+
     def set_abc(self, a, b, c, alpha=90.0, beta=90.0, gamma=90.0, origin=None):
         """
         Set the box using crystal cell lattice parameters and angles.
-        
+
         Parameters
         ----------
         a : float
@@ -562,11 +562,11 @@ class Box(Shape, object):
 
         # Call set_lengths
         self.set_lengths(lx=lx, ly=ly, lz=lz, xy=xy, xz=xz, yz=yz, origin=origin)
-        
+
     def set_lengths(self, lx, ly, lz, xy=0.0, xz=0.0, yz=0.0, origin=None):
         """
         Set the box using LAMMPS box lengths and tilt factors.
-        
+
         Parameters
         ----------
         lx : float
@@ -576,21 +576,21 @@ class Box(Shape, object):
         lz : float
             The LAMMPS box length in the z direction.
         xy : float, optional
-            The LAMMPS box tilt factor in the xy direction.  Default value is 
+            The LAMMPS box tilt factor in the xy direction.  Default value is
             0.0.
         xz : float, optional
-            The LAMMPS box tilt factor in the xz direction.  Default value is 
+            The LAMMPS box tilt factor in the xz direction.  Default value is
             0.0.
         yz : float, optional
-            The LAMMPS box tilt factor in the yz direction.  Default value is 
+            The LAMMPS box tilt factor in the yz direction.  Default value is
             0.0.
         origin : numpy.ndarray, optional
             The 3D vector for the box origin position.  Default value is
             (0,0,0).
         """
-        
+
         assert lx > 0 and ly > 0 and lz > 0, 'box lengths must be positive'
-        
+
         # Set default origin
         if origin is None:
             origin = [0.0, 0.0, 0.0]
@@ -600,11 +600,11 @@ class Box(Shape, object):
                       [xy, ly,  0.0],
                       [xz, yz,  lz]]
         self.origin = origin
-    
+
     def set_hi_los(self, xlo, xhi, ylo, yhi, zlo, zhi, xy=0.0, xz=0.0, yz=0.0):
         """
         Set the box using LAMMPS box hi's, lo's and tilt factors.
-        
+
         Parameters
         ----------
         xlo : float
@@ -620,25 +620,25 @@ class Box(Shape, object):
         zhi : float
             The LAMMPS zhi box hi term.
         xy : float, optional
-            The LAMMPS box tilt factor in the xy direction.  Default value is 
+            The LAMMPS box tilt factor in the xy direction.  Default value is
             0.0.
         xz : float, optional
-            The LAMMPS box tilt factor in the xz direction.  Default value is 
+            The LAMMPS box tilt factor in the xz direction.  Default value is
             0.0.
         yz : float, optional
-            The LAMMPS box tilt factor in the yz direction.  Default value is 
+            The LAMMPS box tilt factor in the yz direction.  Default value is
             0.0.
         """
-        
+
         # Convert to hi and lo term to lengths and origin
         lx = xhi - xlo
         ly = yhi - ylo
         lz = zhi - zlo
         origin = [xlo, ylo, zlo]
-        
+
         # Call set_lengths
         self.set_lengths(lx=lx, ly=ly, lz=lz, xy=xy, xz=xz, yz=yz, origin=origin)
-    
+
     def is_lammps_norm(self):
         """
         Tests if box is compatible with LAMMPS.
@@ -653,7 +653,7 @@ class Box(Shape, object):
             and self.__vects[2,2] > 0.0)
 
     def inside(self, pos, inclusive=True):
-        
+
         # Retrieve the Box's planes
         planes = self.planes
 
@@ -664,3 +664,9 @@ class Box(Shape, object):
                & planes[3].below(pos, inclusive=inclusive)
                & planes[4].below(pos, inclusive=inclusive)
                & planes[5].below(pos, inclusive=inclusive))
+
+    def cart(self, pos):
+        """
+        Return the cartesian coordinates of given fractional coordinates
+        """
+        return np.inner(pos, self.vects.T)

--- a/atomman/core/Box.py
+++ b/atomman/core/Box.py
@@ -45,6 +45,7 @@ class Box(Shape, object):
         """
         self.__vects = np.eye(3, dtype='float64')
         self.__origin = np.zeros(3, dtype='float64')
+        self.__inverse_vects = None
 
         if len(kwargs) > 0:
             if 'model' in kwargs:
@@ -244,8 +245,11 @@ class Box(Shape, object):
     def vects(self, value):
         self.__vects[:] = value
 
-        #Zero out near zero terms
+        # Zero out near zero terms
         self.__vects[np.isclose(self.__vects/abs(self.__vects).max(), 0.0, atol=1e-9)] = 0.0
+
+        # Reset inverse_vects
+        self.__inverse_vects = None
 
     @property
     def origin(self):
@@ -786,5 +790,9 @@ class Box(Shape, object):
         if cartpos.shape[-1] != 3:
             raise ValueError('Invalid position dimensions')
         
+        # Compute inverse_vects if needed
+        if self.__inverse_vects is None:
+            self.__inverse_vects = np.linalg.inv(self.vects)
+
         # Convert and return
-        return (value - self.origin).dot(np.linalg.inv(self.vects))
+        return (value - self.origin).dot(self.__inverse_vects)

--- a/atomman/defect/FreeSurface.py
+++ b/atomman/defect/FreeSurface.py
@@ -1,20 +1,29 @@
+from itertools import product
+
 import numpy as np
 
 from . import free_surface_basis
-from ..tools.crystalsystem import iscubic
 from ..tools import miller
+from ..region import Plane
+
+try:
+    from spglib import get_symmetry_dataset
+    spglib_loaded = True
+except ImportError:
+    spglib_loaded = False
+
 
 class FreeSurface():
     """
-    Class for generating free surface atomic configurations using clean planar slices. 
+    Class for generating free surface atomic configurations using clean planar slices.
     """
-    
+
     def __init__(self, hkl, ucell, cutboxvector='c', maxindex=None,
                  conventional_setting='p', tol=1e-7):
         """
         Class initializer.  Identifies the proper rotations for the given hkl plane
         and cutboxvector, and creates the rotated cell.
-        
+
         Parameters
         ----------
         hkl : array-like object
@@ -40,14 +49,15 @@ class FreeSurface():
             Tolerance parameter used to round off near-zero values.  Default
             value is 1e-8.
         """
-        
+
         # Pass parameters to free_surface_basis to get the rotation uvws
         uvws = free_surface_basis(hkl, box=ucell.box, cutboxvector=cutboxvector, maxindex=maxindex,
                                   conventional_setting=conventional_setting)
-        
+
         # Generate the rotated cell
+        # rcell.box.vects == uvws @ ucell.box.vects @ transform.T
         rcell, transform = ucell.rotate(uvws, return_transform=True)
-        
+
         # Transform uvws to the conventional cell representation
         if uvws.shape == (3,3):
             uvws = miller.vector_primitive_to_conventional(uvws, conventional_setting)
@@ -57,7 +67,7 @@ class FreeSurface():
             if rcell.box.bvect[0] != 0.0 or rcell.box.cvect[0] != 0.0:
                 raise ValueError("box bvect and cvect cannot have x component for cutboxvector='a'")
             cutindex = 0
-        
+
         elif cutboxvector == 'b':
             if rcell.box.avect[1] != 0.0 or rcell.box.cvect[1] != 0.0:
                 raise ValueError("box avect and cvect cannot have y component for cutboxvector='b'")
@@ -67,14 +77,14 @@ class FreeSurface():
             if rcell.box.avect[2] != 0.0 or rcell.box.bvect[2] != 0.0:
                 raise ValueError("box avect and bvect cannot have z component for cutboxvector='c'")
             cutindex = 2
-        
-        # Define out of plane unit vector 
+
+        # Define out of plane unit vector
         ovect = np.zeros(3)
         ovect[cutindex] = 1.0
-        
+
         # Get out of plane width
         rcellwidth = rcell.box.vects[cutindex, cutindex]
-        
+
         # Get the unique coordinates normal to the plane
         pos = rcell.atoms.pos
         numdec = - int(np.floor(np.log10(tol)))
@@ -83,13 +93,13 @@ class FreeSurface():
         # Add periodic replica if missing
         if not np.isclose(coords[-1] - coords[0], rcellwidth, rtol=0.0, atol=tol):
             coords = np.append(coords, coords[0] + rcellwidth)
-            
+
         # Compute the shifts
         relshifts = rcellwidth - (coords[1:] + coords[:-1]) / 2
         relshifts[relshifts > rcellwidth] -= rcellwidth
         relshifts[relshifts < 0.0] += rcellwidth
         shifts = np.outer(np.sort(relshifts), ovect)
-        
+
         # Save attributes
         self.__hkl = np.asarray(hkl)
         self.__ucell = ucell
@@ -106,42 +116,42 @@ class FreeSurface():
     def hkl(self):
         """list : Crystal plane in Miller or Miller-Bravais indices"""
         return self.__hkl
-    
+
     @property
     def ucell(self):
         """atomman.System : The unit cell to use in building the defect system."""
         return self.__ucell
-    
+
     @property
     def rcell(self):
         """atomman.System : the rotated cell to use in building the defect system."""
         return self.__rcell
-    
+
     @property
     def cutboxvector(self):
         """str : The box vector for the cut direction."""
         return self.__cutboxvector
-    
+
     @property
     def cutindex(self):
         """int : The Cartesian index for the cut direction."""
         return self.__cutindex
-    
+
     @property
     def uvws(self):
         """numpy.ndarray : The conventional Miller or Miller-Bravais crystal vectors associated with the rcell box vectors."""
         return self.__uvws
-    
+
     @property
     def rcellwidth(self):
         """float : The width of rcell in the cutindex direction."""
         return self.__rcellwidth
-    
+
     @property
     def shifts(self):
         """list : All shift values that place the fault halfway between atomic layers in rcell."""
         return self.__shifts
-    
+
     @property
     def system(self):
         """atomman.System : The built free surface system."""
@@ -149,7 +159,7 @@ class FreeSurface():
             return self.__system
         except:
             raise AttributeError('system not yet built. Use build_system() or surface().')
-        
+
     @property
     def surfacearea(self):
         """float : The surface area of one of the hkl planes."""
@@ -157,12 +167,12 @@ class FreeSurface():
             return self.__surfacearea
         except:
             raise AttributeError('system not yet built. Use build_system() or surface().')
-        
+
     @property
     def transform(self):
         """numpy.ndarray : The Cartesian transformation tensor associated with rotating from ucell to rcell"""
         return self.__transform
-    
+
     @property
     def conventional_setting(self):
         """str : The lattice setting/centering associated with the conventional cell (used if ucell is primitive)"""
@@ -172,7 +182,7 @@ class FreeSurface():
                 even=False):
         """
         Generates and returns a free surface atomic system.
-        
+
         Parameters
         ----------
         shift : array-like object, optional
@@ -191,10 +201,10 @@ class FreeSurface():
             If given, the sizemult along the cutboxvector will be selected such that the
             width of the resulting final system in that direction will be at least this
             value. If both sizemults and minwidth are given, then the larger of the two
-            in the cutboxvector direction will be used. 
+            in the cutboxvector direction will be used.
         even : bool, optional
             A True value means that the sizemult for cutboxvector will be made an even
-            number by adding 1 if it is odd.  Default value is False.       
+            number by adding 1 if it is odd.  Default value is False.
 
         Returns
         -------
@@ -207,26 +217,26 @@ class FreeSurface():
             shift = np.zeros(3)
         else:
             shift = np.asarray(shift)
-        
+
         if sizemults is None:
             sizemults = [1, 1, 1]
-        
+
         # Handle minwidth
         if minwidth is not None:
             mult = int(np.ceil(minwidth / self.rcellwidth))
-            
+
             sizemult = sizemults[self.cutindex]
             if mult > np.abs(sizemult):
                 sizemults[self.cutindex] = np.sign(sizemult) * mult
-        
+
         # Handle even
         if even and sizemults[self.cutindex] % 2 == 1:
             if sizemults[self.cutindex] > 0:
                 sizemults[self.cutindex] += 1
             else:
                 sizemults[self.cutindex] -= 1
-        
-        # Define out of plane unit vector 
+
+        # Define out of plane unit vector
         ovect = np.zeros(3)
         ovect[self.cutindex] = 1.0
 
@@ -234,20 +244,20 @@ class FreeSurface():
         system = self.rcell.supersize(*sizemults)
         system.atoms.pos += shift
         system.wrap()
-        
+
         # Change system's pbc
         system.pbc = [True, True, True]
         system.pbc[self.cutindex] = False
-        
+
         # Insert vacuumwidth
         if vacuumwidth is not None:
             if vacuumwidth < 0:
                 raise ValueError('vacuumwidth must be positive')
             newvects = system.box.vects
             newvects[self.cutindex, self.cutindex] += vacuumwidth
-            neworigin = system.box.origin - ovect * vacuumwidth / 2 
+            neworigin = system.box.origin - ovect * vacuumwidth / 2
             system.box_set(vects=newvects, origin=neworigin)
-               
+
         # Compute surfacearea based on cutboxvector
         if self.cutboxvector == 'a':
             surfacearea = np.linalg.norm(np.cross(system.box.bvect, system.box.cvect))
@@ -257,9 +267,77 @@ class FreeSurface():
 
         elif self.cutboxvector == 'c':
             surfacearea = np.linalg.norm(np.cross(system.box.avect, system.box.bvect))
-                        
+
         # Save attributes
         self.__system = system
         self.__surfacearea = surfacearea
 
         return self.system
+
+    def unique_shifts(self, symprec: float = 1e-5):
+        """
+        Return symmetrically nonequivalent shifts
+        """
+        if not spglib_loaded:
+            raise ImportError("FreeSurface.unique_shifts requires spglib. Use `pip install spglib`")
+
+        # Get symmetry operations of rotated ucell
+        lattice, positions, numbers = self.ucell.dump('spglib_cell')
+        rotated_lattice = np.dot(lattice, self.transform.T)
+        dataset = get_symmetry_dataset((rotated_lattice, positions, numbers), symprec=symprec)
+        operations = []
+        vects_tinv = np.linalg.inv(rotated_lattice.T)
+        for rotation, translation in zip(dataset['rotations'], dataset['translations']):
+            rotation_cart = np.dot(np.dot(rotated_lattice.T, rotation), vects_tinv)
+            translation_cart = np.inner(translation, rotated_lattice.T)
+            operations.append((rotation_cart, translation_cart))
+
+        # Planes for each shift
+        normal = np.zeros(3)
+        normal[self.cutindex] = 1.0
+        planes = [Plane(normal, shift) for shift in self.shifts]
+
+        unique_shifts = []
+        primitive_vects = dataset['primitive_lattice']
+
+        # List of trial displacements to search for a translation between two planes
+        # The range [-1, 1] may not be sufficient for largely distorted lattice.
+        trial_images = list(product(range(-1, 2), repeat=3))
+
+        def is_equivalent_by_primitive_vects(plane1, plane2):
+            # Check if two planes can be transformed to each other by lattice vectors
+            for image in trial_images:
+                rotation = np.eye(3)
+                translation = np.inner(image, primitive_vects.T)
+                new_plane1 = plane1.operate(rotation, translation)
+                if new_plane1 == plane2:
+                    return True
+            return False
+
+        for i in range(len(self.shifts)):
+            plane_i = planes[i]
+
+            # Obtain symmetrically equvalent planes with the i-th plane
+            equivalent_planes = []
+            for rotation, translation in operations:
+                new_plane = plane_i.operate(rotation, translation)
+                if np.allclose(new_plane.normal, normal) and (new_plane not in equivalent_planes):
+                    equivalent_planes.append(new_plane)
+
+            # Compare with remained shifts
+            is_unique = True
+            for j in range(i + 1, len(self.shifts)):
+                plane_j = planes[j]
+                # Here, the two planes have the normal vector.
+                for plane in equivalent_planes:
+                    if is_equivalent_by_primitive_vects(plane, plane_j):
+                        is_unique = False
+                        break
+
+                if not is_unique:
+                    break
+
+            if is_unique:
+                unique_shifts.append(plane_i.point)
+
+        return np.array(unique_shifts)

--- a/atomman/defect/free_surface_basis.py
+++ b/atomman/defect/free_surface_basis.py
@@ -6,6 +6,7 @@ import numpy as np
 # atomman imports
 from .. import Box, System
 from ..tools import vect_angle, miller, ishexagonal
+from ..tools.miller import vector_crystal_to_cartesian
 
 def free_surface_basis(hkl, box=None, cutboxvector='c', maxindex=None,
                        return_hexagonal=None, return_planenormal=False,
@@ -167,7 +168,8 @@ def free_surface_basis(hkl, box=None, cutboxvector='c', maxindex=None,
         maxindex = int(np.max([np.abs(a_uvw), np.abs(b_uvw), np.abs(hkl)]))
 
     # Compute Cartesian plane normal
-    planenormal = s * np.cross(box.cart(a_uvw), box.cart(b_uvw))
+    planenormal = s * np.cross(vector_crystal_to_cartesian(a_uvw, box),
+                               vector_crystal_to_cartesian(b_uvw, box))
 
     # Build gen_vector iterator for testing vectors
     def gen_vector(n):
@@ -185,12 +187,12 @@ def free_surface_basis(hkl, box=None, cutboxvector='c', maxindex=None,
                                 yield np.array([i, j, k], dtype=int)
 
     # First search
-    a_mag = np.linalg.norm(box.cart([maxindex, maxindex, maxindex]))
+    a_mag = np.linalg.norm(vector_crystal_to_cartesian([maxindex, maxindex, maxindex], box))
     c_angle = 90
     a_uvw = None
     c_uvw = None
     for uvw in gen_vector(maxindex):
-        cart = box.cart(uvw)
+        cart = vector_crystal_to_cartesian(uvw, box)
         mag = np.linalg.norm(cart)
         angle = vect_angle(cart, planenormal)
 
@@ -212,12 +214,12 @@ def free_surface_basis(hkl, box=None, cutboxvector='c', maxindex=None,
     c_uvw = c_uvw / np.gcd.reduce(np.asarray(c_uvw, dtype=int)) # pylint: disable=no-member
 
     # Second search
-    a_cart = box.cart(a_uvw)
-    b_mag = np.linalg.norm(box.cart([maxindex, maxindex, maxindex]))
+    a_cart = vector_crystal_to_cartesian(a_uvw, box)
+    b_mag = np.linalg.norm(vector_crystal_to_cartesian([maxindex, maxindex, maxindex], box))
     b_uvw = None
     min_angle = 180.0
     for uvw in gen_vector(maxindex):
-        cart = box.cart(uvw)
+        cart = vector_crystal_to_cartesian(uvw, box)
         angle = vect_angle(a_cart, cart)
 
         # Check that vector is in plane and not parallel to a_uvw

--- a/atomman/defect/point.py
+++ b/atomman/defect/point.py
@@ -120,7 +120,7 @@ def vacancy(system, pos=None, ptd_id=None, scale=False, atol=None):
             raise ValueError('pos and ptd_id cannot both be supplied')
         
         if scale:
-            pos = system.unscale(pos)
+            pos = system.box.position_relative_to_cartesian(pos)
         
         dist = np.linalg.norm(system.dvect(pos, system.atoms.pos), axis=1)
         ptd_id = np.where(np.isclose(dist, 0.0, atol=atol))
@@ -193,7 +193,7 @@ def interstitial(system, pos, scale=False, atol=None, **kwargs):
         atol = uc.set_in_units(0.01, 'angstrom')
     
     if scale:
-        pos = system.unscale(pos)
+        pos = system.box.position_relative_to_cartesian(pos)
     
     # Check that no atoms are already at pos
     dist = np.linalg.norm(system.dvect(pos, system.atoms.pos), axis=1)
@@ -278,7 +278,7 @@ def substitutional(system, pos=None, ptd_id=None, atype=1,scale=False,
             raise ValueError('pos and ptd_id cannot both be supplied')
         
         if scale:
-            pos = system.unscale(pos)
+            pos = system.box.position_relative_to_cartesian(pos)
         
         dist = np.linalg.norm(system.dvect(pos, system.atoms.pos), axis=1)
         ptd_id = np.where(np.isclose(dist, 0.0, atol=atol))
@@ -376,7 +376,7 @@ def dumbbell(system, pos=None, ptd_id=None, db_vect=None, scale=False,
             raise ValueError('pos and ptd_id cannot both be supplied')
         
         if scale:
-            pos = system.unscale(pos)
+            pos = system.box.position_relative_to_cartesian(pos)
         
         dist = np.linalg.norm(system.dvect(pos, system.atoms.pos), axis=1)
         ptd_id = np.where(np.isclose(dist, 0.0, atol=atol))
@@ -396,7 +396,7 @@ def dumbbell(system, pos=None, ptd_id=None, db_vect=None, scale=False,
         
     # Unscale db_vect
     if scale:
-        db_vect = system.unscale(db_vect)
+        db_vect = system.box.position_relative_to_cartesian(db_vect)
     
     # Generate atomic index list for defect
     index = list(range(system.natoms))

--- a/atomman/load/table/load.py
+++ b/atomman/load/table/load.py
@@ -102,7 +102,7 @@ def load(table, box, symbols=None, system=None, prop_name=None, table_name=None,
         
         if prop['unit'] is not None:
             if prop['unit'] == "scaled":
-                value = system.unscale(value)
+                value = system.box.position_relative_to_cartesian(value)
             else:
                 value = uc.set_in_units(value, prop['unit'])
         value = np.asarray(value, dtype=prop['dtype'])

--- a/atomman/region/Plane.py
+++ b/atomman/region/Plane.py
@@ -1,7 +1,10 @@
 # coding: utf-8
+from __future__ import annotations
 
 # http://www.numpy.org/
 import numpy as np
+
+from ..tools import vect_angle
 
 class Plane():
     """
@@ -10,7 +13,7 @@ class Plane():
     def __init__(self, normal, point):
         """
         Defines a plane in space.
-        
+
         Parameters
         ----------
         normal : array-like object
@@ -18,88 +21,117 @@ class Plane():
         point : array-like object
             3D vector coordinate of any point in the plane.
         """
-        
+
         # Set values
-        self.normal = normal 
+        self.normal = normal
         self.point = point
-    
+
     @property
     def normal(self):
         """numpy.NDArray : 3D normal unit vector of the plane."""
         return self.__normal
-    
+
     @normal.setter
     def normal(self, value):
-        
+
         # Check that value is proper
         value = np.asarray(value)
         assert value.shape == (3,), "point must be a 3D vector"
-        
+
         # Save normalvector as a unit vector
         self.__normal = value / np.linalg.norm(value)
-    
+
     @property
     def point(self):
         """numpy.NDArray : a 3D vector position on the plane."""
         return self.__point
-    
+
     @point.setter
     def point(self, value):
-        
+
         # Check that value is proper
         value = np.asarray(value)
         assert value.shape == (3,), "point must be a 3D vector"
-        
+
         # Save
         self.__point = value
-    
+
     def below(self, pos, inclusive=True):
         """
         Indicates if position(s) are below the plane.  Note that identifying
         points as above or below is dependent on the sign of the plane normal.
-        
+
         Parameters
         ----------
         pos : array-like object
-            Nx3 array of coordinates. 
+            Nx3 array of coordinates.
         inclusive : bool, optional
             Indicates if points in the plane are to be included.
             Default value is True.
-            
+
         Returns
         -------
         numpy.NDArray
             N array of bool values: True if below the plane
         """
-        
-        # Ensure pos is a numpy array 
+
+        # Ensure pos is a numpy array
         pos = np.asarray(pos)
-        
+
         # Determine above/below based on dot product with plane normal vector
         normpoint = np.dot(self.normal, self.point)
         normpos = np.inner(self.normal, pos)
-        
+
         if inclusive:
             return normpos <= normpoint
         else:
             return normpos < normpoint
-    
+
     def above(self, pos, inclusive=False):
         """
         Indicates if position(s) are above the plane.  Note that identifying
         points as above or below is dependent on the sign of the plane normal.
-        
+
         Parameters
         ----------
         pos : array-like object
-            Nx3 array of coordinates. 
+            Nx3 array of coordinates.
         inclusive : bool, optional
             Indicates if points in the plane are to be included.
             Default value is False.
-        
+
         Returns
         -------
         numpy.NDArray
             N array of bool values: True if above the plane
         """
         return ~self.below(pos, inclusive=not inclusive)
+
+    def operate(self, rotation, translation) -> Plane:
+        """
+        Return a new plane transformed by given symmetry operation
+
+        Parameters
+        ----------
+        rotation: array-like, (3, 3)
+            rotation matrix in cartedian coordinates
+        translation: array-like, (3, )
+            translation matrix in cartedian coordinates
+        """
+        rotation = np.array(rotation)
+        translation = np.array(translation)
+
+        new_normal = np.dot(np.linalg.inv(rotation.T), self.normal)
+        new_point = np.dot(rotation, self.point) + translation
+        return Plane(new_normal, new_point)
+
+    def __eq__(self, other: Plane) -> bool:
+        if self is other:
+            return True
+
+        # check if normals are parallel
+        if not np.isclose(vect_angle(self.normal, other.normal), 0):
+            return False
+
+        # check if the point is contained in the other plane
+        return np.isclose(np.dot(other.normal, self.point - other.point), 0)

--- a/atomman/region/Plane.py
+++ b/atomman/region/Plane.py
@@ -126,12 +126,38 @@ class Plane():
         return Plane(new_normal, new_point)
 
     def __eq__(self, other: Plane) -> bool:
+        """
+        Compare with a given plane within default tolerance parameters
+        """
         if self is other:
             return True
 
+        return self.isclose(other)
+
+    def isclose(self, other: Plane, rtol: float = 1e-5, atol: float = 1e-8):
+        """
+        Check the plane and a given one represent the same.
+        Note that if the normal vectors of the two planes are antiparallel, they are considered to be different.
+
+        Parameters
+        ----------
+        other: Plane
+            a plane to be compared with
+        rtol: float
+            the relative tolerance parameter used in numpy.isclose
+        atol: float
+            the absolute tolerance parameter used in numpy.isclose
+
+        Returns
+        -------
+        bool:
+            Return true if the plane and a given one represent the same within tolerance.
+        """
         # check if normals are parallel
-        if not np.isclose(vect_angle(self.normal, other.normal), 0):
+        angle = vect_angle(self.normal, other.normal, unit='radian')
+        if not np.isclose(angle, 0.0, rtol=rtol, atol=atol):
             return False
 
         # check if the point is contained in the other plane
-        return np.isclose(np.dot(other.normal, self.point - other.point), 0)
+        projected = np.dot(other.normal, self.point - other.point)
+        return np.isclose(projected, 0.0, rtol=rtol, atol=atol)

--- a/tests/defect/test_free_surface.py
+++ b/tests/defect/test_free_surface.py
@@ -4,6 +4,7 @@ import pytest
 import atomman.unitconvert as uc
 from atomman import Box, Atoms, System
 from atomman.defect import FreeSurface, free_surface_basis
+from atomman.tools.miller import vector_crystal_to_cartesian
 
 
 @pytest.fixture
@@ -123,9 +124,9 @@ def _test_free_surface_basis(box: Box, hkl):
         return_planenormal=True,
     )
 
-    v1 = box.cart(uvws[0])
-    v2 = box.cart(uvws[1])
-    v3 = box.cart(uvws[2])
+    v1 = vector_crystal_to_cartesian(uvws[0], box)
+    v2 = vector_crystal_to_cartesian(uvws[1], box)
+    v3 = vector_crystal_to_cartesian(uvws[2], box)
 
     # check if v1 and v2 are on (hkl) plane
     np.testing.assert_almost_equal(np.dot(v1, planenormal), 0)

--- a/tests/defect/test_free_surface.py
+++ b/tests/defect/test_free_surface.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pytest
+
+import atomman.unitconvert as uc
+from atomman import Box, Atoms, System
+from atomman.defect import FreeSurface, free_surface_basis
+
+
+@pytest.fixture
+def bcc_Fe() -> System:
+    a = uc.set_in_units(2.866, "angstrom")
+    box = Box.cubic(a)
+    atoms = Atoms(pos=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]])
+    system = System(atoms=atoms, box=box, scale=True, symbols="Fe")
+    return system
+
+
+@pytest.fixture
+def alpha_Fe2O3() -> System:
+    """
+    Working example from W. Sun and G. Cedar, Surface Science, 617, 53-59 (2013).
+    """
+    # mp-19770
+    a = uc.get_in_units(5.10485225, "angstrom")
+    c = uc.get_in_units(13.91329700, "angstrom")
+    box = Box.hexagonal(a, c)
+
+    pos = [
+        [0.00000000, 0.00000000, 0.85417500],
+        [0.00000000, 0.00000000, 0.14582500],
+        [0.66666667, 0.33333333, 0.97915833],
+        [0.33333333, 0.66666667, 0.02084167],
+        [0.66666667, 0.33333333, 0.18750833],
+        [0.66666667, 0.33333333, 0.47915833],
+        [0.33333333, 0.66666667, 0.31249167],
+        [0.00000000, 0.00000000, 0.35417500],
+        [0.33333333, 0.66666667, 0.52084167],
+        [0.33333333, 0.66666667, 0.81249167],
+        [0.00000000, 0.00000000, 0.64582500],
+        [0.66666667, 0.33333333, 0.68750833],
+        [0.97154417, 0.33333333, 0.08333333],
+        [0.02845583, 0.66666667, 0.91666667],
+        [0.66666667, 0.63821083, 0.08333333],
+        [0.33333333, 0.36178917, 0.91666667],
+        [0.36178917, 0.02845583, 0.08333333],
+        [0.63821083, 0.97154417, 0.91666667],
+        [0.63821083, 0.66666667, 0.41666667],
+        [0.69512250, 0.00000000, 0.25000000],
+        [0.33333333, 0.97154417, 0.41666667],
+        [0.00000000, 0.69512250, 0.25000000],
+        [0.02845583, 0.36178917, 0.41666667],
+        [0.30487750, 0.30487750, 0.25000000],
+        [0.30487750, 0.00000000, 0.75000000],
+        [0.36178917, 0.33333333, 0.58333333],
+        [0.00000000, 0.30487750, 0.75000000],
+        [0.66666667, 0.02845583, 0.58333333],
+        [0.69512250, 0.69512250, 0.75000000],
+        [0.97154417, 0.63821083, 0.58333333],
+    ]
+    atype = [1] * 12 + [2] * 18
+    atoms = Atoms(atype=atype, pos=pos)
+
+    symbols = ("Fe", "O")
+    system = System(atoms=atoms, box=box, scale=True, symbols=symbols)
+    return system
+
+
+def test_free_surface_basis_cubic(bcc_Fe):
+    box = bcc_Fe.box
+    _test_free_surface_basis(box, [1, 0, 0])
+    _test_free_surface_basis(box, [0, 2, 0])
+    _test_free_surface_basis(box, [0, 0, 3])
+    _test_free_surface_basis(box, [0, 1, -1])
+    _test_free_surface_basis(box, [2, 0, 3])
+    _test_free_surface_basis(box, [4, 5, 0])
+    _test_free_surface_basis(box, [1, 2, -3])
+
+
+def test_free_surface_basis_hexagonal(alpha_Fe2O3):
+    box = alpha_Fe2O3.box
+    _test_free_surface_basis(box, [1, 0, -1, 4])
+    _test_free_surface_basis(box, [1, 0, 0])
+    _test_free_surface_basis(box, [0, 2, 0])
+    _test_free_surface_basis(box, [0, 0, 3])
+    _test_free_surface_basis(box, [0, 1, -1])
+    _test_free_surface_basis(box, [2, 0, 3])
+    _test_free_surface_basis(box, [4, 5, 0])
+    _test_free_surface_basis(box, [1, 2, -3])
+
+
+def _test_free_surface_basis(box: Box, hkl):
+    uvws, planenormal = free_surface_basis(
+        hkl=hkl,
+        box=box,
+        return_hexagonal=False,
+        return_planenormal=True,
+    )
+
+    v1 = box.cart(uvws[0])
+    v2 = box.cart(uvws[1])
+    v3 = box.cart(uvws[2])
+
+    # check if v1 and v2 are on (hkl) plane
+    np.testing.assert_almost_equal(np.dot(v1, planenormal), 0)
+    np.testing.assert_almost_equal(np.dot(v2, planenormal), 0)
+
+    # check right-handedness
+    assert np.dot(np.cross(v1, v2), v3) > 0
+
+    # check if v3 is out of (hkl) plane
+    assert np.dot(v3, planenormal) > 0

--- a/tests/dump_load/test_atom_data.py
+++ b/tests/dump_load/test_atom_data.py
@@ -11,14 +11,15 @@ from atomman.load import FileFormatError
 
 class Test_atom_data:
 
-    def load_dump(self, system1, atom_style=None, units=None):
+    def load_dump(self, system1, atom_style=None, units=None, potential=None):
         """
         Utility function that dumps, loads, and dumps, then asserts two dumps
         are equivalent
         """
         # dump system1 to content1
         content1 = system1.dump('atom_data', atom_style=atom_style,
-                                units=units, return_info=False)
+                                units=units, potential=potential,
+                                return_info=False)
 
         # load content1 to system2
         system2 = am.load('atom_data', content1, pbc=system1.pbc,
@@ -27,7 +28,8 @@ class Test_atom_data:
 
         # dump system2 to content2
         content2 = system2.dump('atom_data', atom_style=atom_style,
-                                units=units, return_info=False)
+                                units=units, potential=potential,
+                                return_info=False)
 
         # Check that the two dumps are equivalent
         assert content1 == content2

--- a/tests/dump_load/test_atom_data.py
+++ b/tests/dump_load/test_atom_data.py
@@ -11,26 +11,24 @@ from atomman.load import FileFormatError
 
 class Test_atom_data:
 
-    def load_dump(self, system1, atom_style=None, units=None, potential=None):
+    def load_dump(self, system1, atom_style=None, units=None):
         """
         Utility function that dumps, loads, and dumps, then asserts two dumps
         are equivalent
         """
         # dump system1 to content1
         content1 = system1.dump('atom_data', atom_style=atom_style,
-                                units=units, potential=potential,
-                                return_info=False)
+                                units=units, return_info=False)
 
         # load content1 to system2
         system2 = am.load('atom_data', content1, pbc=system1.pbc,
                           symbols=system1.symbols, atom_style=atom_style,
-                          units=units, potential=potential)
+                          units=units)
 
         # dump system2 to content2
         content2 = system2.dump('atom_data', atom_style=atom_style,
-                                units=units, potential=potential,
-                                return_info=False)
-        
+                                units=units, return_info=False)
+
         # Check that the two dumps are equivalent
         assert content1 == content2
 
@@ -56,7 +54,7 @@ class Test_atom_data:
                 '2 1 2.3982049184958 4.0169567962790 0.4422255026206',
                 '3 1 1.6332403214635 1.8356166738031 0.3819388814516',
                 '4 1 1.2352186803268 0.3081624624139 0.5885979440072']
-    
+
     def test_goodfile(self):
         """Test that full data_lines is valid"""
         content = '\n'.join(self.data_lines)
@@ -71,7 +69,7 @@ class Test_atom_data:
 
     def test_badfile_no_box(self):
         """Raise FileFormatError if any *lo *hl lines are missing"""
-        
+
         # missing xlo xhi
         content = '\n'.join(self.data_lines[:3] + self.data_lines[4:])
         with pytest.raises(FileFormatError):
@@ -95,7 +93,7 @@ class Test_atom_data:
             am.load('atom_data', content)
 
     def test_atomic_no_imageflags(self):
-        
+
         box = am.Box(vects=[[1.25694013, 0.        , 0.        ],
                             [1.17551244, 4.01690452, 0.        ],
                             [0.23122344, 0.0768582 , 0.76391945]])
@@ -107,13 +105,13 @@ class Test_atom_data:
         symbols = 'Al'
         pbc = (True, True, True)
 
-        system = am.System(atoms=atoms, box=box, scale=True, 
+        system = am.System(atoms=atoms, box=box, scale=True,
                            symbols=symbols, pbc=pbc)
 
         self.load_dump(system, atom_style='atomic', units='metal')
 
     def test_atomic_imageflags(self):
-        
+
         box = am.Box(vects=[[1.25694013, 0.        , 0.        ],
                             [1.17551244, 4.01690452, 0.        ],
                             [0.23122344, 0.0768582 , 0.76391945]])
@@ -125,7 +123,7 @@ class Test_atom_data:
         symbols = 'Al'
         pbc = (True, True, True)
 
-        system = am.System(atoms=atoms, box=box, scale=True, 
+        system = am.System(atoms=atoms, box=box, scale=True,
                            symbols=symbols, pbc=pbc)
-        
+
         self.load_dump(system, atom_style='atomic', units='metal')

--- a/tests/region/test_plane.py
+++ b/tests/region/test_plane.py
@@ -1,7 +1,14 @@
-import pytest
 import numpy as np
 
 from atomman.region import Plane
+
+
+def test_isclose():
+    plane1 = Plane(normal=[1, 0, 0], point=[1, 0, 0])
+    plane2 = Plane(normal=[1.0001, 0, 0], point=[1.0001, 1, 1])
+    assert plane1 != plane2
+    assert plane1.isclose(plane2, rtol=1e-4, atol=1e-4)
+    assert plane2.isclose(plane1, rtol=1e-4, atol=1e-4)
 
 
 def test_equality():

--- a/tests/region/test_plane.py
+++ b/tests/region/test_plane.py
@@ -1,0 +1,26 @@
+import pytest
+import numpy as np
+
+from atomman.region import Plane
+
+
+def test_equality():
+    plane1 = Plane(normal=[1, 0, 0], point=[1, 0, 0])
+    plane2 = Plane(normal=[1, 0, 0], point=[1, 1, 1])
+    plane3 = Plane(normal=[-1, 0, 0], point=[1, 0, 0])
+    assert plane1 == plane2
+    assert plane1 != plane3
+
+
+def test_operate():
+    plane = Plane(normal=[1, 0, 0], point=[1, 0, 0])
+    # Rotate 90 degree along z-axis
+    rotation = [
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1],
+    ]
+    translation = [0, 0, 0.5]
+    new_plane = plane.operate(rotation, translation)
+    np.testing.assert_almost_equal(new_plane.normal, [0, 1, 0])
+    np.testing.assert_almost_equal(new_plane.point, [0, 1, 0.5])

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,22 +1,10 @@
 # coding: utf-8
 
 # Standard Python libraries
-import os
-
-# https://docs.pytest.org/en/latest/
-import pytest
-
-# http://www.numpy.org/
-import numpy as np
+from importlib import resources
 
 import atomman as am
 
-def test_rootdir():
-    assert os.path.isdir(am.rootdir)
-
 def test_version():
-    assert os.path.isfile(os.path.join(os.path.join(am.rootdir, 'VERSION')))
-    try:
-        print('Testing atomman version', am.__version__)
-    except:
-        assert False
+    assert resources.is_resource('atomman', 'VERSION')
+    print('Testing atomman version', am.__version__)

--- a/tests/tools/test_atomic_info.py
+++ b/tests/tools/test_atomic_info.py
@@ -8,26 +8,23 @@ from atomman.tools import atomic_mass, atomic_symbol, atomic_number
 class Test_atomic_info:
     def test_atomic_symbol(self):
         assert atomic_symbol(74) == 'W'
-        
+
         with pytest.raises(IndexError):
             atomic_symbol(0)
-        
+
         with pytest.raises(IndexError):
             atomic_symbol(119)
 
     def test_atomic_number(self):
         assert atomic_number('Fe') == 26
-        
+
         with pytest.raises(ValueError):
             atomic_number('Nt')
-        
+
     def test_atomic_mass(self):
         assert atomic_mass(77) == 192.217
 
         assert atomic_mass('He-9') == 9.043946
-
-        with pytest.raises(ValueError):
-            atomic_mass(118)
 
         with pytest.raises(IndexError):
             atomic_mass(119)

--- a/tests/tools/test_miller.py
+++ b/tests/tools/test_miller.py
@@ -7,74 +7,217 @@ import pytest
 import numpy as np
 
 import atomman as am
-from atomman.tools.miller import (vector3to4, vector4to3,
-                                  vector_conventional_to_primitive,
-                                  vector_crystal_to_cartesian,
-                                  vector_primitive_to_conventional)
+from atomman.tools.miller import *
 
-def test_vector3to4():
-    assert np.all(vector3to4([ 1, 2, 3]) == np.array([ 0, 1,-1, 3]))
-    assert np.all(vector3to4([ 0, 3, 0]) == np.array([-1, 2,-1, 0]))
-    assert np.all(vector3to4([-3, 0, 1]) == np.array([-2, 1, 1, 1]))
-    assert np.all(vector3to4([-2, 2, 2]) == np.array([-2, 2, 0, 2]))
-    with pytest.raises(ValueError):
-        vector3to4([ 1, 2, 3, 4])
+class TestMiller():
 
+    @property
+    def cubbox(self):
+        """A cubic box for testing conversions"""
+        return am.Box.cubic(a=4)
 
-def test_vector4to3():
-    assert np.all(vector4to3([ 0, 1,-1, 3]) == np.array([ 1, 2, 3]))
-    assert np.all(vector4to3([-1, 2,-1, 0]) == np.array([ 0, 3, 0]))
-    assert np.all(vector4to3([-2, 1, 1, 1]) == np.array([-3, 0, 1]))
-    assert np.all(vector4to3([-2, 2, 0, 2]) == np.array([-2, 2, 2]))
-    with pytest.raises(ValueError):
-        vector4to3([ 1, 2, 3])
+    @property
+    def hexbox(self):
+        """A hexagonal box for testing conversions"""
+        return am.Box.hexagonal(a=3, c=5)
 
-def test_vector_crystal_to_cartesian():
-    # Test 3 indices
-    box = am.Box(a=3, b=4, c=5, alpha=90, beta=90, gamma=90)
-    assert np.allclose(vector_crystal_to_cartesian([1,2,3], box),
-                       np.array([ 3, 8, 15]))
-
-    box = am.Box(a=3, b=4, c=5, alpha=90, beta=90, gamma=80)
-    assert np.allclose(vector_crystal_to_cartesian([1,1,1], box),
-                       np.array([[3.69459271, 3.93923101, 5.        ]]))
-    # Test 4 indices
-    box = am.Box(a=3, b=3, c=5, alpha=90, beta=90, gamma=120)
-    assert np.allclose(vector_crystal_to_cartesian([-2, 1, 1, 1], box),
-                       np.array([-9, 0, 5]))
+    @property
+    def vector3(self):
+        """3 index vectors corresponding to the vector4 4 index vectors."""
+        return np.array([[ 1, 2, 3],
+                         [ 0, 3, 0],
+                         [-3, 0, 1],
+                         [-2, 2, 2]])
     
-    box = am.Box(a=3, b=4, c=5, alpha=90, beta=90, gamma=120)
-    with pytest.raises(ValueError):
-        vector_crystal_to_cartesian([-2, 1, 1, 1], box)
+    @property
+    def vector4(self):
+        """4 index vectors corresponding to the vector3 3 index vectors."""
+        return np.array([[ 0, 1,-1, 3],
+                         [-1, 2,-1, 0],
+                         [-2, 1, 1, 1],
+                         [-2, 2, 0, 2]])
 
-def test_vector_primitive_to_conventional():
-    prim = np.array([[ 0.,  1.,  2.],
-                     [-3., -2.,  0.],
-                     [-3.,  1., -1.],
-                     [ 2.,  0., -3.]])
-    iset = np.array([[-1.5, -0.5,  0.5],
-                     [-0.5, -2.5, -0.5],
-                     [-1.5, -0.5, -2.5],
-                     [ 2.5,  2.5, -0.5]])
-    fset = np.array([[ 0.5,  1. ,  1.5],
-                     [-2.5, -1.5, -1. ],
-                     [-1. , -2. ,  0. ],
-                     [ 1. , -0.5, -1.5]])
-    assert np.allclose(vector_primitive_to_conventional(prim, 'i'), iset)
-    assert np.allclose(vector_primitive_to_conventional(prim, 'f'), fset)
+    @property
+    def plane3(self):
+        """3 index planes corresponding to the plane4 4 index planes."""
+        return np.array([[ 3, 3, 3],
+                         [ 1, 1, 0],
+                         [-2, 4, 0],
+                         [-1,-3, 5],
+                         [ 3, 3,-5]])
+    
+    @property
+    def plane4(self):
+        """4 index planes corresponding to the plane3 3 index planes."""
+        return np.array([[ 3, 3,-6, 3],
+                         [ 1, 1,-2, 0],
+                         [-2, 4,-2, 0],
+                         [-1,-3, 4, 5],
+                         [ 3, 3,-6,-5]])
 
-def test_vector_conventional_to_primitive():
-    prim = np.array([[ 0.,  1.,  2.],
-                     [-3., -2.,  0.],
-                     [-3.,  1., -1.],
-                     [ 2.,  0., -3.]])
-    iset = np.array([[-1.5, -0.5,  0.5],
-                     [-0.5, -2.5, -0.5],
-                     [-1.5, -0.5, -2.5],
-                     [ 2.5,  2.5, -0.5]])
-    fset = np.array([[ 0.5,  1. ,  1.5],
-                     [-2.5, -1.5, -1. ],
-                     [-1. , -2. ,  0. ],
-                     [ 1. , -0.5, -1.5]])
-    assert np.allclose(vector_conventional_to_primitive(iset, 'i'), prim)
-    assert np.allclose(vector_conventional_to_primitive(fset, 'f'), prim)                     
+    @property
+    def prim(self):
+        """A set of primitive lattice vectors corresponding to iset and fset"""
+        return np.array([[ 0.,  1.,  2.],
+                         [-3., -2.,  0.],
+                         [-3.,  1., -1.],
+                         [ 2.,  0., -3.]])
+
+    @property
+    def iset(self):
+        """A set of body-centered lattice vectors corresponding to prim"""
+        return np.array([[-1.5, -0.5,  0.5],
+                         [-0.5, -2.5, -0.5],
+                         [-1.5, -0.5, -2.5],
+                         [ 2.5,  2.5, -0.5]])
+
+    @property
+    def fset(self):
+        """A set of face-centered lattice vectors corresponding to prim"""
+        return np.array([[ 0.5,  1. ,  1.5],
+                         [-2.5, -1.5, -1. ],
+                         [-1. , -2. ,  0. ],
+                         [ 1. , -0.5, -1.5]])
+
+
+
+    def test_vector3to4(self):
+        """test vector3to4 by checking that vector3 -> vector4"""
+        # Test giving single vectors
+        for vector3, vector4 in zip(self.vector3, self.vector4):
+            assert np.all(vector3to4(vector3) == vector4)
+
+        # Test giving array of vectors
+        assert np.all(vector3to4(self.vector3) == self.vector4)
+
+        # Test for invalid array shape
+        with pytest.raises(ValueError):
+            vector3to4([ 1, 2, 3, 4])
+
+    def test_vector4to3(self):
+        """test test_vector4to3 by checking that vector4 -> vector3"""
+        # Test giving single vectors
+        for vector4, vector3 in zip(self.vector4, self.vector3):
+            assert np.all(vector4to3(vector4) == vector3)
+
+        # Test giving array of vectors
+        assert np.all(vector4to3(self.vector4) == self.vector3)
+
+        # Test for invalid array shape
+        with pytest.raises(ValueError):
+            vector4to3([ 1, 2, 3])
+
+    def test_plane3to4(self):
+        """test plane3to4 by checking that plane3 -> plane4"""
+        # Test giving single plane
+        for plane3, plane4 in zip(self.plane3, self.plane4):
+            assert np.allclose(plane3to4(plane3), plane4)
+
+        # Test giving array of planes
+        assert np.allclose(plane3to4(self.plane3), self.plane4)
+
+        # Test for invalid array shape
+        with pytest.raises(ValueError):
+            plane3to4([ 1, 2, 3, 4])
+
+    def test_plane4to3(self):
+        """test plane4to3 by checking that plane4 -> plane3"""
+        # Test giving single plane
+        for plane4, plane3 in zip(self.plane4, self.plane3):
+            assert np.all(plane4to3(plane4) == plane3)
+
+        # Test giving array of planes
+        assert np.all(plane4to3(self.plane4) == self.plane3)
+
+        # Test for invalid array shape
+        with pytest.raises(ValueError):
+            plane4to3([ 1, 2, 3])
+
+    
+    
+    def test_vector_crystal_to_cartesian(self):
+        """
+        test vector_crystal_to_cartesian using cubbox and hexbox boxes
+        and vector3 and vector4 crystal vector sets.        
+        """
+        # Define the Cartesian answers
+        cubcart = 4 * self.vector3
+        hexcart = np.array([[ 0.0, 3*3**0.5,  15.0],
+                            [-4.5, 4.5*3**0.5, 0.0],
+                            [-9.0, 0.0,        5.0],
+                            [-9.0, 3*3**0.5,  10.0]])
+
+        # Test cubic with individual vector3 values
+        for vector3, cart in zip(self.vector3, cubcart):
+            assert np.allclose(vector_crystal_to_cartesian(vector3, self.cubbox), cart)
+
+        # Test cubic with all vector3 values
+        assert np.allclose(vector_crystal_to_cartesian(self.vector3, self.cubbox), cubcart)
+
+        # Test hexagonal with individual vector3 values
+        for vector3, cart in zip(self.vector3, hexcart):
+            assert np.allclose(vector_crystal_to_cartesian(vector3, self.hexbox), cart)
+
+        # Test hexagonal with all vector3 values   
+        assert np.allclose(vector_crystal_to_cartesian(self.vector3, self.hexbox), hexcart)
+
+        # Test hexagonal with vector4
+        assert np.allclose(vector_crystal_to_cartesian(self.vector4, self.hexbox), hexcart)
+        
+        # Check that vector4 fails for cubic
+        with pytest.raises(ValueError):
+            vector_crystal_to_cartesian(self.vector4, self.cubbox)
+
+    def test_plane_crystal_to_cartesian(self):
+        """
+        test plane_crystal_to_cartesian using cubbox and hexbox boxes
+        and plane3 and plane4 crystal vector sets.  
+        """
+        # Define the Cartesian answers
+        cubcart = (self.plane3.T / np.linalg.norm(self.plane3, axis=1)).T
+        hexcart = np.array([[ 0.47891314,  0.8295019 ,  0.28734789],
+                            [ 0.5       ,  0.8660254 , -0.        ],
+                            [-0.5       ,  0.8660254 , -0.        ],
+                            [-0.19487094, -0.78756153,  0.58461282],
+                            [ 0.4472136 ,  0.77459667, -0.4472136 ]])
+
+        # Test cubic with individual plane3 values
+        for plane3, cart in zip(self.plane3, cubcart):
+            assert np.allclose(plane_crystal_to_cartesian(plane3, self.cubbox), cart)
+
+        # Test cubic with all plane3 values
+        assert np.allclose(plane_crystal_to_cartesian(self.plane3, self.cubbox), cubcart)
+
+        # Test hexagonal with individual plane3 values
+        for plane3, cart in zip(self.plane3, hexcart):
+            assert np.allclose(plane_crystal_to_cartesian(plane3, self.hexbox), cart)
+
+        # Test hexagonal with all plane3 values
+        assert np.allclose(plane_crystal_to_cartesian(self.plane3, self.hexbox), hexcart)
+
+        # Test hexagonal with plane4
+        assert np.allclose(plane_crystal_to_cartesian(self.plane4, self.hexbox), hexcart)
+        
+        # Check that plane4 fails for cubic
+        with pytest.raises(ValueError):
+            plane_crystal_to_cartesian(self.plane4, self.cubbox)
+
+
+
+    def test_vector_primitive_to_conventional(self):
+        """
+        test vector_primitive_to_conventional by checking that prim converts
+        to prim, iset, or fset based on basis
+        """
+        assert np.allclose(vector_primitive_to_conventional(self.prim, 'p'), self.prim)
+        assert np.allclose(vector_primitive_to_conventional(self.prim, 'i'), self.iset)
+        assert np.allclose(vector_primitive_to_conventional(self.prim, 'f'), self.fset)
+
+    def test_vector_conventional_to_primitive(self):
+        """
+        test vector_conventional_to_primitive by checking that prim, iset,
+        and fset convert to prim with the appropriate basis
+        """
+        assert np.allclose(vector_conventional_to_primitive(self.prim, 'p'), self.prim)
+        assert np.allclose(vector_conventional_to_primitive(self.iset, 'i'), self.prim)
+        assert np.allclose(vector_conventional_to_primitive(self.fset, 'f'), self.prim)                     


### PR DESCRIPTION
`FreeSurface.shifts` returns candidates for terminations of free surfaces. However, Some of the terminations are identical under symmetry operations of `ucell`. This PR implements `unique_shifts` method which returns the nonequivalent terminations under symmetry operations. This function will be useful to avoid duplicated surface calculations.

Procedure for filtering nonequivalent shifts are as follows:
1. analyze a space group of `ucell` by `spglib`
2. create `Plane` objects to represent `shift` and apply symmetry operations in the space group to them
3. If planes are identical with some symmetry operation and lattice translation, choose one of them

I have added a unit test for (100) surfaces of anatase, which is a working example from Section 2.4 of [Sun and Ceder (2013)](https://www.sciencedirect.com/science/article/abs/pii/S003960281300160X?via%3Dihub). I have verified that `unique_shifts` function correctly returns the result with the article: there are two possible shifts and they are identical under a glide operation.
