### PR TITLE
Unique shifts further testing and updates

### DIFF
--- a/atomman/defect/FreeSurface.py
+++ b/atomman/defect/FreeSurface.py
@@ -13,10 +13,10 @@ from ..region import Plane
 from .. import System
 
 try:
-    from spglib import get_symmetry_dataset
-    spglib_loaded = True
+    import spglib
+    has_spglib = True
 except ImportError:
-    spglib_loaded = False
+    has_spglib = False
 
 
 class FreeSurface():
@@ -292,7 +292,6 @@ class FreeSurface():
     def unique_shifts(self,
                       symprec: float = 1e-5,
                       trial_image_range: int = 1,
-                      rtol: float = 1e-5,
                       atol: float = 1e-8) -> np.ndarray:
         """
         Return symmetrically nonequivalent shifts
@@ -305,8 +304,6 @@ class FreeSurface():
             Maximum cell images searched in finding translationally equivalent planes.
             The default value is one, which corresponds to search the 27 neighbor images, [-1, 1]^3.
             The default value may not be sufficient for largely distorted lattice.
-        rtol: float
-            the relative tolerance used in comparing two crystal planes
         atol: float
             the absolute tolerance used in comparing two crystal planes
 
@@ -314,7 +311,7 @@ class FreeSurface():
         -------
         unique_shifts: np.ndarray, (# of unique shifts, 3)
         """
-        if not spglib_loaded:
+        if not has_spglib:
             raise ImportError("FreeSurface.unique_shifts requires spglib. Use `pip install spglib`")
         if (not isinstance(trial_image_range, int)) or (trial_image_range <= 0):
             raise ValueError("trial_image_range should be positive integer.")
@@ -322,7 +319,7 @@ class FreeSurface():
         # Get symmetry operations of rotated ucell
         lattice, positions, numbers = self.ucell.dump('spglib_cell')
         rotated_lattice = np.dot(lattice, self.transform.T)
-        dataset = get_symmetry_dataset((rotated_lattice, positions, numbers), symprec=symprec)
+        dataset = spglib.get_symmetry_dataset((rotated_lattice, positions, numbers), symprec=symprec)
         operations = []
         vects_tinv = np.linalg.inv(rotated_lattice.T)
         for rotation, translation in zip(dataset['rotations'], dataset['translations']):
@@ -336,7 +333,8 @@ class FreeSurface():
         planes = [Plane(normal, shift) for shift in self.shifts]
 
         unique_shifts = []
-        primitive_vects = dataset['primitive_lattice']
+        primitive_lattice = spglib.standardize_cell((rotated_lattice, positions, numbers),  to_primitive=True)[0]
+        #primitive_lattice = dataset['primitive_lattice']
 
         # List of trial displacements to search for a translation between two planes
         # The range [-1, 1] may not be sufficient for largely distorted lattice.
@@ -346,16 +344,16 @@ class FreeSurface():
             # Check if two planes can be transformed to each other by lattice vectors
             for image in trial_images:
                 rotation = np.eye(3)
-                translation = np.inner(image, primitive_vects.T)
+                translation = np.inner(image, primitive_lattice.T)
                 new_plane1 = plane1.operate(rotation, translation)
-                if new_plane1.isclose(plane2, rtol=rtol, atol=atol):
+                if new_plane1.isclose(plane2, atol=atol):
                     return True
             return False
 
         for i in range(len(self.shifts)):
             plane_i = planes[i]
 
-            # Obtain symmetrically equvalent planes with the i-th plane
+            # Obtain symmetrically equivalent planes with the i-th plane
             equivalent_planes = []
             for rotation, translation in operations:
                 new_plane = plane_i.operate(rotation, translation)
@@ -365,7 +363,7 @@ class FreeSurface():
                     continue
 
                 # If the new plane is already found, skip it.
-                if any([new_plane.isclose(plane, rtol=rtol, atol=atol) for plane in equivalent_planes]):
+                if any([new_plane.isclose(plane, atol=atol) for plane in equivalent_planes]):
                     continue
 
                 equivalent_planes.append(new_plane)
@@ -388,3 +386,121 @@ class FreeSurface():
 
         unique_shifts = np.array(unique_shifts)
         return unique_shifts
+
+    def unique_shifts2(self,
+                    symprec: float = 1e-5,
+                    return_fingerprints: bool = False
+                    ) -> np.ndarray:
+        """
+        Returns a set of shifts that are assoiciated with pairs of symetrically unique
+        termination planes.  The algorithm first identifies which atomic planes in the
+        rotated cells are symmetrically equivalent.  The returned shifts correspond to
+        positions between each unique pair of unique planes.  NOTE: This algorithm
+        cannot tell if different termination plane pairs are equivalent to others, e.g.
+        for aabb stacking, aa, ab, bb, and ba will all be returned even if aa == bb
+        and/or ab == ba.
+
+        Parameters
+        ----------
+        symprec: float
+            Absolute distance tolerance used in spglib to find symmetries
+            and used here to compare planes.
+        return_fingerprints: bool
+            Setting this to True will return the termination plane pair fingerprints
+            associated with each unique shift.
+            
+        Returns
+        -------
+        unique_shifts: np.ndarray (# of unique shifts, 3)
+            The shifts that result in unique pairs of termination planes
+        fingerprints: list
+            Gives the two unique planes that make up the termination planes.
+        """
+        if not has_spglib:
+            raise ImportError("FreeSurface.unique_shifts requires spglib. Use `pip install spglib`")
+
+        # Extract class attributes
+        rcell = self.rcell
+        cutindex = self.cutindex
+            
+        # Define out of plane vector, i.e. plane normal
+        ovect = np.zeros(3)
+        ovect[cutindex] = 1.0
+
+        # Get spglib symmetry info for the rotated cell
+        dataset = spglib.get_symmetry_dataset(rcell.dump('spglib_cell'), symprec=symprec)
+        
+        # Get out of plane width
+        rcellwidth = rcell.box.vects[cutindex, cutindex]
+
+        # Get the unique coordinates normal to the plane
+        pos = rcell.atoms.pos
+        numdec = - int(np.floor(np.log10(symprec)))
+        coords = np.unique(pos[:, cutindex].round(numdec))
+
+        # Add periodic replica if missing
+        if not np.isclose(coords[-1] - coords[0], rcellwidth, rtol=0.0, atol=symprec):
+            coords = np.append(coords, coords[0] + rcellwidth)
+        
+        equivalent_planes = np.full_like(coords, -1, dtype=int)
+
+        # Loop over all coordinates of atomic planes (except periodic replica)
+        for i in range(len(coords)-1):
+
+            # Skip if plane is already identified
+            if equivalent_planes[i] != -1:
+                continue
+
+            # Create Plane object for the atomic plane
+            plane_i = Plane(ovect, coords[i] * ovect)
+
+            # Set plane's id to the next available value
+            p = np.max(equivalent_planes) + 1
+            equivalent_planes[i] = p
+
+            # Loop over all remaining coords  (except periodic replica)
+            for j in range(i+1, len(coords)-1):
+
+                # Skip if plane is already identified
+                if equivalent_planes[j] != -1:
+                    continue
+
+                pos_j = coords[j] * ovect
+
+                # Loop over all symmetry operations
+                for rotation, translation in zip(dataset['rotations'], dataset['translations']):
+
+                    # Apply the symmetry operation and wrap into the cell.
+                    # Note that operations are performed in box relative units
+                    relative_pos = rcell.box.position_cartesian_to_relative(pos_j)
+                    symmetry_pos = np.dot(rotation, relative_pos) + translation
+                    symmetry_pos -= np.floor(symmetry_pos)
+                    test_pos = rcell.box.position_relative_to_cartesian(symmetry_pos)
+
+                    # Check if test plane matches plane_i
+                    test_plane = Plane(ovect, test_pos)
+                    if plane_i.isclose(test_plane, atol=symprec):
+                        equivalent_planes[j] = i
+                        break
+
+        # Set periodic replica
+        equivalent_planes[-1] = equivalent_planes[0]
+        
+        
+        fingerprints = []
+        unique_shifts = []
+        letters = 'abcdefghijklmnopqrstuvwxyz'
+        
+        for i in range(len(coords)-1, 0, -1):
+            fingerprint = letters[equivalent_planes[i-1]] + letters[equivalent_planes[i]]
+            relshift = rcellwidth - (coords[i] + coords[i-1]) / 2
+            if fingerprint in fingerprints:
+                continue
+
+            unique_shifts.append(np.dot(ovect, relshift))
+            fingerprints.append(fingerprint)
+        
+        if return_fingerprints:
+            return np.array(unique_shifts), fingerprints
+        else:
+            return np.array(unique_shifts)

--- a/atomman/defect/FreeSurface.py
+++ b/atomman/defect/FreeSurface.py
@@ -333,8 +333,8 @@ class FreeSurface():
         planes = [Plane(normal, shift) for shift in self.shifts]
 
         unique_shifts = []
-        primitive_lattice = spglib.standardize_cell((rotated_lattice, positions, numbers),  to_primitive=True)[0]
-        #primitive_lattice = dataset['primitive_lattice']
+        primitive_vects = spglib.standardize_cell((rotated_lattice, positions, numbers),  to_primitive=True)[0]
+        #primitive_vects = dataset['primitive_lattice']
 
         # List of trial displacements to search for a translation between two planes
         # The range [-1, 1] may not be sufficient for largely distorted lattice.
@@ -344,7 +344,7 @@ class FreeSurface():
             # Check if two planes can be transformed to each other by lattice vectors
             for image in trial_images:
                 rotation = np.eye(3)
-                translation = np.inner(image, primitive_lattice.T)
+                translation = np.inner(image, primitive_vects.T)
                 new_plane1 = plane1.operate(rotation, translation)
                 if new_plane1.isclose(plane2, atol=atol):
                     return True

--- a/atomman/dump/primitive_cell/__init__.py
+++ b/atomman/dump/primitive_cell/__init__.py
@@ -1,0 +1,1 @@
+from .dump import dump

--- a/atomman/dump/primitive_cell/dump.py
+++ b/atomman/dump/primitive_cell/dump.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+# Standard Python libraries
+from typing import Optional
+
+# https://atztogo.github.io/spglib/python-spglib.html
+try:
+    import spglib
+    has_spglib = True
+except ImportError:
+    has_spglib = False
+
+
+# atomman imports
+from ... import System, load_spglib_cell
+
+
+
+def dump(system: System,
+         symprec: float = 1e-5,
+         no_idealize: bool = False,
+         normalize: Optional[str] = 'lammps') -> System:
+    """
+    Converts a given system into a primitive unit cell.  NOTE: This works best for small systems,
+    e.g. conventional unit cells or relatively small and standard supercells.
+
+    Parameters
+    ----------
+    system : atomman.System
+        A atomman representation of a system.
+    symprec : float, optional
+        Absolute length tolerance to use in identifying symmetry of atomic
+        sites and system boundaries. Default value is 1e-5.
+    no_idealize : bool, optional
+        Indicates if the atom positions in the returned unit cell are averaged
+        (True) or idealized based on the structure (False).  Default value is
+        False.
+    normalize : str or None
+        Indicates if the 
+    """
+    assert has_spglib, 'spglib must be installed to use dump primitive cell'
+
+    # Convert to spglib cell
+    cell = system.dump('spglib_cell')
+    
+    # Use spglib to identify the primitive cell
+    primitive_cell = spglib.standardize_cell(cell, to_primitive=True,
+                                             symprec=symprec, no_idealize=no_idealize)
+    
+    # Convert back to an atomman System and normalize
+    primitive_system = load_spglib_cell(primitive_cell, symbols=system.symbols)
+    
+    # Normalize
+    if normalize is not None:
+        primitive_system = primitive_system.normalize(normalize)
+        
+    return primitive_system

--- a/atomman/region/Plane.py
+++ b/atomman/region/Plane.py
@@ -150,7 +150,6 @@ class Plane():
 
     def isclose(self,
                 other: Plane,
-                rtol: float = 1e-5,
                 atol: float = 1e-8) -> bool:
         """
         Check the plane and a given one represent the same.
@@ -172,9 +171,9 @@ class Plane():
         """
         # check if normals are parallel
         angle = vect_angle(self.normal, other.normal, unit='radian')
-        if not np.isclose(angle, 0.0, rtol=rtol, atol=atol):
+        if not np.isclose(angle, 0.0, rtol=0.0, atol=atol):
             return False
 
         # check if the point is contained in the other plane
         projected = np.dot(other.normal, self.point - other.point)
-        return np.isclose(projected, 0.0, rtol=rtol, atol=atol)
+        return np.isclose(projected, 0.0, rtol=0.0, atol=atol)


### PR DESCRIPTION
@lan496,

I created a new branch for unique-shifts as my tests show that it is not working as well as I think it should.  When I loop over hkl sets with different prototypes (https://github.com/lmhale99/potentials-library/tree/master/free_surface)  I see that the unique_shifts method still returns a large number of shifts despite the fact that most or all should be the same.

Small updates to your method:
- The isclose of Plane now only has atol and not rtol.  Since the two internal isclose comparisons are with 0.0, rtol is meaningless.
- spglib.standardize_cell((rotated_lattice, positions, numbers),  to_primitive=True) is used to get the primitive lattice vectors instead of dataset.  This is done for better compatibility as dataset['primitive_lattice'] is a relatively recent addition to spglib.

I tried to figure out what your method was doing, but I wasn't entirely sure so I tried doing my own (unique_shifts2)

- In my first attempt, I used the spglib dataset operation on rcell then tried to apply the transformations to find which shifts are unique.  Noting that the spglib symmetry operations are for relative box vectors, I took what I do in wrap to avoid the need of the trial image search.  This did not identify all unique planes as the symmetry of the shift planes does not reflect the symmetry of the system.  For instance for dc (111), the atomic planes are not evenly spaced but the shifts are...
- Next, I used the symmetry operations on the atomic planes rather than the shift planes.  This has been added as unique_shifts2.  This (mostly) seems to identify unique atomic planes, which then allows for unique shifts based on pairs of termination planes.  This seems much better, but is still limited in that I think it is missing some distinct shifts and it is unable to tell if some termination plane sets are equivalent to others.

Maybe look over the two methods and see if you can see how to improve either.

Alternatively, I think the most complete method would be to take all of the rcell + shift systems and compare the atomic positions in those systems for equivalency. 
-  The shifts always place the free surface halfway between two atomic planes.
- Knowing the systems are "2D" limits the transformation and rotation searches needed. 
  - in-plane translations where atoms in an end plane are translated to other positions in the same plane.
  - 180 degree flips and inversions
  - 3- or 4-fold rotations about the plane normal if it is compatible with the cell.  This is perhaps the hardest one.

I also added code for a system dump style that uses spglib to return a primitive unit cell.  While the code works if copied somewhere else, it is not incorporated into atomman as doing so would create recursive imports at the moment...


