### PR TITLE
Fix deprecated argument for DataFrame.to_csv

### DIFF
--- a/atomman/dump/atom_dump/dump.py
+++ b/atomman/dump/atom_dump/dump.py
@@ -261,26 +261,26 @@ def table_dump(system,
             df['supos[0]'] = spos[:,0]
             df['supos[1]'] = spos[:,1]
             df['supos[2]'] = spos[:,2]
-    
+
     # Loop over all properties
     for prop in prop_info:
         pname = prop['prop_name']
-        
+
         # loop over all table names and property indexes
         for tname, (index, istr) in zip(prop['table_name'], # pylint: disable=unused-variable
                                         indexstr(prop['shape'])):
-            
+
             # Build name change dict
             key_rename[pname + istr] = tname
-            
+
             # Convert units if needed
             if prop['unit'] is not None:
                 df[pname + istr] = uc.get_in_units(df[pname + istr], prop['unit'])
-    
+
     # Rename and reorganize
     df = df.rename(columns=key_rename)[list(key_rename.values())]
-  
+
     # Generate table
     sep = ' '
     return df.to_csv(path_or_buf=f, sep=sep, index=None, header=False,
-                     float_format=float_format, line_terminator='\n')
+                     float_format=float_format, lineterminator='\n')

--- a/atomman/dump/table/dump.py
+++ b/atomman/dump/table/dump.py
@@ -138,20 +138,20 @@ def dump(system,
                       header=header,
                       float_format=float_format,
                       encoding='ascii',
-                      line_terminator='\n',
+                      lineterminator='\n',
                       )
-    
+
     returns = []
-    
+
     if table is not None:
         returns.append(table)
-    
+
     if return_prop_info is True:
         returns.append(prop_info)
-        
+
     if len(returns) == 1:
         return returns[0]
     elif len(returns) > 1:
         return tuple(returns)
-    
+
     return


### PR DESCRIPTION
The argument `line_terminator` for `pandas.DataFrame.to_csv` is deprecated in `pandas==1.5.0` and removed in `pandas==2.0.0`. This PR changes the deprecated argument `line_terminator` to `lineterminator`.
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html